### PR TITLE
feature/cli-error-handling

### DIFF
--- a/bioio_conversion/bin/cli_batch_convert.py
+++ b/bioio_conversion/bin/cli_batch_convert.py
@@ -83,28 +83,40 @@ def main(
     """
     Batch-convert images via CSV, directory walk, or explicit list.
     """
-    # Parse extra options
-    default_opts: Dict[str, Any] = parse_extra_opts(extra_opts)
+    try:
+        # Parse extra options
+        default_opts: Dict[str, Any] = parse_extra_opts(extra_opts)
 
-    bc = BatchConverter(default_opts=default_opts)
+        bc = BatchConverter(default_opts=default_opts)
 
-    mode_lower = mode.lower()
-    if mode_lower == "csv":
-        if csv_file is None:
-            raise click.BadParameter("--csv-file is required in csv mode")
-        jobs = bc.from_csv(Path(csv_file))
-    elif mode_lower == "dir":
-        if directory is None:
-            raise click.BadParameter("--directory is required in dir mode")
-        jobs = bc.from_directory(Path(directory), max_depth=depth, pattern=pattern)
-    else:  # list
-        if not paths:
-            raise click.BadParameter("--paths is required in list mode")
-        jobs = bc.from_list(list(paths))
+        mode_lower = mode.lower()
+        if mode_lower == "csv":
+            if csv_file is None:
+                raise click.BadParameter("--csv-file is required in csv mode")
+            jobs = bc.from_csv(Path(csv_file))
+        elif mode_lower == "dir":
+            if directory is None:
+                raise click.BadParameter("--directory is required in dir mode")
+            jobs = bc.from_directory(
+                Path(directory),
+                max_depth=depth,
+                pattern=pattern,
+            )
+        else:  # list
+            if not paths:
+                raise click.BadParameter("--paths is required in list mode")
+            jobs = bc.from_list(list(paths))
 
-    click.echo(f"Discovered {len(jobs)} job(s), commencing conversion…")
-    bc.run_jobs(jobs)
-    click.echo("Batch conversion complete.")
+        click.echo(f"Discovered {len(jobs)} job(s), commencing conversion…")
+        bc.run_jobs(jobs)
+        click.echo("Batch conversion complete.")
+
+    except click.BadParameter:
+        raise
+    except KeyboardInterrupt:
+        raise click.Abort()
+    except Exception as e:
+        raise click.ClickException(f"Batch conversion failed: {e}")
 
 
 if __name__ == "__main__":

--- a/bioio_conversion/bin/cli_convert.py
+++ b/bioio_conversion/bin/cli_convert.py
@@ -457,9 +457,15 @@ def main(
             w_start=channel_window_start,
             w_end=channel_window_end,
         )
-
-    conv = OmeZarrConverter(source=source, **init_opts)
-    conv.convert()
+    try:
+        conv = OmeZarrConverter(source=source, **init_opts)
+        conv.convert()
+    except FileExistsError as e:
+        raise click.ClickException(str(e))
+    except KeyboardInterrupt:
+        raise click.Abort()
+    except Exception as e:
+        raise click.ClickException(f"Conversion failed: {e}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description 

The purpose of this PR is to add error reporting for CLI commands which previously could fail silently. it aims to add tooling to support #22. It also adds some logging for `KeyboardInterrupt`. Now failed commands will appear as follows:

```
(conversion-univ-api) brian.whitney@OSXLT4XM09M bioio-conversion % bioio-convert does_not_exist.tif -d out_dir

Usage: bioio-convert [OPTIONS] SOURCE
Try 'bioio-convert --help' for help.

Error: Invalid value for 'SOURCE': Path 'does_not_exist.tif' does not exist.
(conversion-univ-api) brian.whitney@OSXLT4XM09M bioio-conversion % bioio-convert multi_scene.ome.tiff -d zarr_out -s not_an_int

Usage: bioio-convert [OPTIONS] SOURCE
Try 'bioio-convert --help' for help.

Error: Invalid value for '--scenes' / '-s': 'not_an_int' is not a valid --scenes value. Use a single index or comma-separated list (e.g. '0,2').
(conversion-univ-api) brian.whitney@OSXLT4XM09M bioio-conversion % bioio-convert image.tif -d out_explicit \
  --level-shapes "1,3,5,325,475;this_is_bad;1,3,1,81,119"

Usage: bioio-convert [OPTIONS] SOURCE
Try 'bioio-convert --help' for help.

Error: Invalid value for '--level-shapes': '1,3,5,325,475;this_is_bad;1,3,1,81,119' is not a valid semicolon-separated list of int tuples. Example: '1,1,16,256,256;1,1,16,128,128'
```