### PR TITLE
bugfix/channel-override

### DIFF
--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -216,13 +216,28 @@ class OmeZarrConverter:
     def _resolve_channels(
         self, axis_names: List[str], channel_count: int
     ) -> Optional[List[Channel]]:
-        if "c" not in axis_names:
-            return None
+        """
+        Resolve channel metadata for the writer.
+
+        Policy:
+        - If the user explicitly provided channels, always honor them
+        (even if no 'c' axis is present).
+        - Otherwise, only derive channels if a 'c' axis exists.
+        """
+
+        # 1. User explicitly supplied channels → always use them
         if self._writer_channels is not None:
             return self._writer_channels
+
+        # 2. No channel axis → no channels to derive
+        if "c" not in axis_names:
+            return None
+
+        # 3. Derive minimal channels from BioImage metadata
         labels = self.bioimage.channel_names or [
             f"Channel:{i}" for i in range(channel_count)
         ]
+
         return [Channel(label=lab, color="#FFFFFF") for lab in labels[:channel_count]]
 
     def _native_axes_and_shape_for_scene(


### PR DESCRIPTION
## Description 
The purpose of this PR is to resolve #27, The reason this bug was happening is we would check for a channel axis to append channel information. This moves the override up in priority so the channel metadata will be written even if the source file does not contain a Channel dimension.