### PR TITLE
feature/common-cli-params

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,111 +216,155 @@ bc.run_jobs(jobs)
 
 ---
 
-## Command-Line Interface: `bioio-convert`
+## Command-Line Interface
 
-Single-file converter using the configured backend (default: OME-Zarr).
+### `bioio-convert` – single-file conversion
+
+Convert a single image file to OME-Zarr using the configured backend
+(default: OME-Zarr).
 
 ```bash
 bioio-convert SOURCE -d DESTINATION [options]
 ```
 
-**Key options:**
+`SOURCE` is the input image file (e.g. `.czi`, `.ome.tiff`, `.nd2`).
+
+**Core options**
 
 * `source` (positional): input image path
-* `-d`, `--destination`: output directory for `.ome.zarr`
-* `-n`, `--name`: base name (defaults to source stem)
-* `-s`, `--scenes`: scene(s) to export (`0` by default; comma-separated list; `None` = all scenes)
-* `--tbatch`: timepoints per write batch (default: `1`)
-* `--start-t-src`: source T index to begin reading (default: 0)
-* `--start-t-dest`: destination T index to begin writing (default: 0)
+* `-d`, `--destination`: output directory for `.ome.zarr` (required)
+* `-n`, `--name`: base name for the output (defaults to a value derived from
+  the input)
+* `-s`, `--scenes`: scene(s) to export (e.g. `0` or `0,2`). If omitted, the
+  converter/writer default is used (“all scenes”).
+* `--tbatch`: number of timepoints per write batch.
+* `--start-t-src`: source T index at which to begin reading (0-based).
+* `--start-t-dest`: destination T index at which to begin writing (0-based).
 
-**Multiscale:**
+**Multiscale (pyramid) options**
 
-* `--level-shapes`: semicolon-separated absolute shapes (level 0 first)
-* `--num-levels`: number of pyramid levels (including level 0)
-* `--downsample-z`: include Z in half-pyramid downsampling
+* `--level-shapes`: semicolon-separated per-level shapes (level 0 first).
+  Each tuple must have one integer per axis.
 
-**Chunking / shards:**
+  * Example:
+    `--level-shapes "1,3,5,512,512;1,3,5,256,256;1,3,5,128,128"`
+* `--num-levels`: total number of pyramid levels (including level 0). If
+  provided (and `--level-shapes` is not), a half-pyramid is built in X/Y
+  (and optionally Z).
+* `--downsample-z`: when used with `--num-levels`, also halves the Z
+  dimension at each level if a Z axis exists.
 
-* `--chunk-shape`: explicit chunk shape (e.g. `1,1,16,256,256`)
-* `--chunk-shape-per-level`: semicolon-separated chunk shapes per level
-* `--memory-target`: bytes per chunk (default: 16 MB)
-* `--shard-shape`: shard shape (Zarr v3 only)
-* `--shard-shape-per-level`: per-level shard shapes (Zarr v3 only)
+**Chunking / sharding (advanced)**
 
-**Writer / metadata:**
+* `--chunk-shape`: single chunk shape tuple applied to all levels
+  (e.g. `1,1,16,256,256`).
+* `--chunk-shape-per-level`: semicolon-separated chunk shapes per level.
+  Overrides `--chunk-shape` and `--memory-target`.
+* `--memory-target`: approximate in-memory byte budget used to derive
+  per-level chunk shapes when explicit chunk shapes are not provided.
+* `--shard-shape`: single shard shape tuple for Zarr v3
+  (e.g. `1,1,128,1024,1024`).
+* `--shard-shape-per-level`: semicolon-separated shard shapes per level
+  (Zarr v3). Overrides `--shard-shape`.
 
-* `--dtype`: output dtype override (e.g. `uint16`; default: reader’s dtype)
-* `--physical-pixel-sizes`: comma-separated floats (per axis, level-0)
-* `--zarr-format`: `2` (NGFF 0.4) or `3` (NGFF 0.5); default: writer decides
+**Writer / metadata options**
 
-**Channels:**
+* `--dtype`: output dtype override (e.g. `uint16`, `float32`). If omitted,
+  the reader’s native dtype is used.
+* `--physical-pixel-sizes`: comma-separated floats (one per axis, level 0
+  only). Example for `(t,c,z,y,x)`:
+  `--physical-pixel-sizes 1.0,1.0,0.4,0.108,0.108`
+* `--zarr-format`: target Zarr version:
+
+  * `2` ≈ NGFF 0.4
+  * `3` ≈ NGFF 0.5
+    If omitted, the writer’s default is used (`3` ≈ NGFF 0.5).
+
+**Channel display options**
+
+These only take effect when `--channel-labels` is provided. All lists must
+align by channel index.
 
 * `--channel-labels`: comma-separated channel names
-* `--channel-colors`: comma-separated colors (hex or CSS names)
-* `--channel-actives`: channel visibility flags (`true,false,...`)
-* `--channel-coefficients`: per-channel coefficient floats
-* `--channel-families`: intensity family names (`linear,sRGB,...`)
-* `--channel-inverted`: channel inversion flags
-* `--channel-window-min/max/start/end`: per-channel windowing values
+  (e.g. `DAPI,GFP,TRITC`).
+* `--channel-colors`: comma-separated colors (CSS color names or hex codes).
+  Example: `"#0000FF,#00FF00,#FF0000"`.
+* `--channel-actives`: booleans for channel visibility
+  (e.g. `true,true,false`).
+* `--channel-coefficients`: per-channel intensity coefficients
+  (e.g. `1,0.8,1.2`).
+* `--channel-families`: intensity family names per channel
+  (e.g. `linear,sRGB,sRGB`).
+* `--channel-inverted`: booleans for inverted display per channel.
+* `--channel-window-min`, `--channel-window-max`,
+  `--channel-window-start`, `--channel-window-end`: per-channel windowing
+  values. Only used when any window value is provided.
 
-**Axis:**
-+* `--axes-names`: comma-separated axis names (metadata only)
-+* `--axes-types`: comma-separated axis types (`time,channel,space,...`)
-+* `--axes-units`: comma-separated axis units; use `none` or blank for missing
+**Axis metadata options**
 
-### Examples
+* `--axes-names`: comma-separated axis names in native axis order.
+  Example: `t,c,z,y,x`.
+* `--axes-types`: comma-separated axis semantic types
+  (e.g. `time,channel,space,space,space`).
+* `--axes-units`: comma-separated axis units, in the same order as
+  `--axes-names`. Use `none`, `null`, or a blank position for missing units.
+  Example for `(t,c,z,y,x)`:
+  `s,,um,um,um`.
 
-#### Basic usage
+### `bioio-convert` examples
+
+**Basic usage**
 
 ```bash
 bioio-convert image.tif -d out_dir
 ```
 
-#### Custom name
+**Custom name**
 
 ```bash
 bioio-convert sample.czi -d out_dir -n my_run
 ```
 
-#### Export all scenes
+**Export all scenes**
 
 ```bash
 bioio-convert multi_scene.ome.tiff -d zarr_out
 ```
 
-#### Export specific scenes
+**Export specific scenes**
 
 ```bash
 bioio-convert multi_scene.ome.tiff -d zarr_out -s 0,2
 ```
 
-#### Simple half-pyramid (XY only)
+**Simple half-pyramid (XY only)**
 
 ```bash
 bioio-convert volume.tif -d out_xy --num-levels 3
 ```
 
-#### Simple half-pyramid (XYZ)
+**Simple half-pyramid (XYZ)**
 
 ```bash
 bioio-convert volume_tczyx.tif -d out_xyz --num-levels 3 --downsample-z
 ```
 
-#### Explicit level shapes
+**Explicit level shapes**
 
 ```bash
 bioio-convert image.tif -d out_explicit \
   --level-shapes "1,3,5,325,475;1,3,2,162,238;1,3,1,81,119"
 ```
 
-#### Dtype and chunking
+**Dtype and chunking**
 
 ```bash
-bioio-convert image.tif -d out_dir --dtype uint16 --memory-target 33554432
+bioio-convert image.tif -d out_dir \
+  --dtype uint16 \
+  --memory-target 33554432
 ```
 
-#### Custom channels
+**Custom channels**
 
 ```bash
 bioio-convert image_with_channels.czi -d out_dir \
@@ -329,33 +373,73 @@ bioio-convert image_with_channels.czi -d out_dir \
   --channel-actives true,true,false
 ```
 
-#### Axis Metadata
-```
-bioio-convert image_tczyx.tif -d out_axes \
---axes-names t,c,z,y,x \
---axes-types time,channel,space,space,space \
---axes-units s,,um,um,um
-```
-
-#### Physical pixel sizes
+**Axis metadata**
 
 ```bash
-bioio-convert image.tif -d out_dir --physical-pixel-sizes 1.0,1.0,0.4,0.108,0.108
+bioio-convert image_tczyx.tif -d out_axes \
+  --axes-names t,c,z,y,x \
+  --axes-types time,channel,space,space,space \
+  --axes-units s,,um,um,um
+```
+
+**Physical pixel sizes**
+
+```bash
+bioio-convert image.tif -d out_dir \
+  --physical-pixel-sizes 1.0,1.0,0.4,0.108,0.108
 ```
 
 ---
 
-## Command-Line Interface: `bioio-batch-convert`
+### `bioio-batch-convert` – batch conversion
 
-Batch mode: convert many files via CSV, directory walk, or explicit list.
+Batch mode: convert many files via CSV, directory walk, or an explicit list
+of paths. All of the shared OME-Zarr options listed for `bioio-convert`
+(`--num-levels`, `--chunk-shape`, `--channel-*`, axis metadata, etc.) are
+also accepted here and act as defaults for every job.
 
 ```bash
-bioio-batch-convert --mode [csv|dir|list] [options]
+bioio-batch-convert --mode [csv|dir|list] [mode options] [shared options]
 ```
 
-### Examples
+**Mode selection**
 
-#### CSV mode
+* `-m`, `--mode [csv|dir|list]` (required):
+
+  * `csv`: read jobs from a CSV file.
+  * `dir`: scan a directory tree for input files.
+  * `list`: use an explicit list of paths from the command line.
+
+**Mode-specific options**
+
+* CSV mode (`--mode csv`)
+
+  * `--csv-file`: path to a CSV describing jobs (one row per job). Each
+    column name maps to an `OmeZarrConverter` init argument (e.g. `source`,
+    `destination`, `scenes`, `tbatch`, etc.). Values are parsed by the batch
+    loader; per-row values override shared defaults from the CLI.
+
+* Directory mode (`--mode dir`)
+
+  * `--directory` / `--dir`: root directory to scan.
+  * `--depth`: maximum recursion depth (0 = only top-level files).
+  * `--pattern`: glob pattern used when scanning (e.g. "*.czi").
+
+* List mode (`--mode list`)
+
+  * `--paths`: explicit input file paths (repeatable).
+
+**Shared conversion options**
+
+All of the `bioio-convert` options (destination, multiscale, chunking,
+channels, axes, etc.) can be passed to `bioio-batch-convert`. They are
+converted via `build_ome_zarr_init_opts(...)` and applied as defaults to
+every job created by the `BatchConverter`. CSV columns that match a given
+argument override the shared defaults on a per-job basis.
+
+### `bioio-batch-convert` examples
+
+**CSV mode**
 
 ```bash
 bioio-batch-convert \
@@ -367,7 +451,7 @@ bioio-batch-convert \
   --num-levels 3
 ```
 
-#### Directory mode
+**Directory mode**
 
 ```bash
 bioio-batch-convert \
@@ -379,7 +463,7 @@ bioio-batch-convert \
   --level-shapes "1,3,5,325,475;1,3,2,162,238;1,3,1,81,119"
 ```
 
-#### List mode
+**List mode**
 
 ```bash
 bioio-batch-convert \
@@ -387,9 +471,9 @@ bioio-batch-convert \
   --paths a.czi b.czi c.tiff \
   --destination list_out \
   --name batch_run \
-  --num-levels 2 --downsample-z
+  --num-levels 2 \
+  --downsample-z
 ```
-
 ---
 
 ## License & Issues

--- a/bioio_conversion/bin/cli_batch_convert.py
+++ b/bioio_conversion/bin/cli_batch_convert.py
@@ -100,34 +100,38 @@ def main(
           --destination out
     """
     try:
-        # Map Click params → OmeZarrConverter kwargs, then coerce to a plain
-        # dict[str, Any] for BatchConverter's type signature.
         init_opts_typed = build_ome_zarr_init_opts(**kwargs)
         default_opts: Dict[str, Any] = dict(init_opts_typed)
 
         bc = BatchConverter(default_opts=default_opts)
 
-        if mode.lower() == "csv":
+        mode_lower = mode.lower()
+        if mode_lower == "csv":
             if csv_file is None:
-                raise click.BadParameter("--csv-file is required in csv mode")
+                raise click.UsageError("--csv-file is required when --mode csv")
             jobs = bc.from_csv(Path(csv_file))
-        elif mode.lower() == "dir":
+
+        elif mode_lower == "dir":
             if directory is None:
-                raise click.BadParameter("--directory is required in dir mode")
-            jobs = bc.from_directory(
-                Path(directory),
-                max_depth=depth,
-                pattern=pattern,
-            )
-        else:
+                raise click.UsageError("--directory/--dir is required when --mode dir")
+            jobs = bc.from_directory(Path(directory), max_depth=depth, pattern=pattern)
+
+        else:  # list
             if not paths:
-                raise click.BadParameter("--paths is required in list mode")
+                raise click.UsageError(
+                    "At least one --paths is required when --mode list"
+                )
             jobs = bc.from_list(list(paths))
 
         click.echo(f"Discovered {len(jobs)} job(s), commencing conversion…")
         bc.run_jobs(jobs)
         click.echo("Batch conversion complete.")
+
+    except KeyboardInterrupt:
+        raise click.Abort()
+
     except click.ClickException:
         raise
+
     except Exception as e:
-        raise click.ClickException(f"Batch conversion failed: {e}")
+        raise click.ClickException(f"Conversion failed: {e}")

--- a/bioio_conversion/bin/cli_batch_convert.py
+++ b/bioio_conversion/bin/cli_batch_convert.py
@@ -1,26 +1,10 @@
-import json
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import click
 
 from ..converters.batch_converter import BatchConverter
-
-
-def parse_extra_opts(extra_opts: Tuple[str, ...]) -> Dict[str, Any]:
-    """
-    Parse KEY=VALUE pairs into a dict, JSON-decode values when possible.
-    """
-    opts: Dict[str, Any] = {}
-    for kv in extra_opts:
-        if "=" not in kv:
-            continue
-        key, val = kv.split("=", 1)
-        try:
-            opts[key] = json.loads(val)
-        except json.JSONDecodeError:
-            opts[key] = val
-    return opts
+from .ome_zarr_options import build_ome_zarr_init_opts, ome_zarr_options
 
 
 @click.command()
@@ -29,48 +13,46 @@ def parse_extra_opts(extra_opts: Tuple[str, ...]) -> Dict[str, Any]:
     "-m",
     type=click.Choice(["csv", "dir", "list"], case_sensitive=False),
     required=True,
-    help="Batch mode: csv, dir, or list",
+    help=(
+        "Batch mode: read jobs from a CSV, scan a directory, or use an "
+        "explicit list of paths."
+    ),
 )
 @click.option(
     "--csv-file",
     type=click.Path(exists=True, dir_okay=False),
     default=None,
-    help="Path to CSV file describing jobs (required in csv mode)",
+    help="Path to CSV describing jobs (required when --mode csv).",
 )
 @click.option(
     "--directory",
+    "--dir",
     type=click.Path(exists=True, file_okay=False),
     default=None,
-    help="Root directory to scan (required in dir mode)",
+    help="Root directory to scan (required when --mode dir).",
 )
 @click.option(
     "--depth",
-    "-d",
     type=int,
     default=0,
     show_default=True,
-    help="Max recursion depth when scanning (dir mode)",
+    help=(
+        "Max recursion depth when scanning directories (dir mode). "
+        "0 = only top-level files."
+    ),
 )
 @click.option(
     "--pattern",
-    "-p",
     default="*",
     show_default=True,
-    help="Glob pattern to match files (dir mode)",
+    help="Glob pattern used when scanning directories (dir mode).",
 )
 @click.option(
     "--paths",
-    "-P",
     multiple=True,
-    help="Explicit file paths (required in list mode)",
+    help=("Explicit input file paths (required when --mode list). " "Repeatable."),
 )
-@click.option(
-    "--opt",
-    "-o",
-    "extra_opts",
-    multiple=True,
-    help="Extra converter init options as KEY=VALUE",
-)
+@ome_zarr_options(require_destination=True)
 def main(
     mode: str,
     csv_file: Optional[str],
@@ -78,23 +60,58 @@ def main(
     depth: int,
     pattern: str,
     paths: Tuple[str, ...],
-    extra_opts: Tuple[str, ...],
+    **kwargs: Any,
 ) -> None:
     """
-    Batch-convert images via CSV, directory walk, or explicit list.
+    Batch-convert images to OME-Zarr.
+
+    This CLI supports three job-discovery modes:
+
+    - csv: Read one job per row from a CSV file. Each column name maps to an
+      OmeZarrConverter init argument (for example source, destination,
+      scenes, tbatch). Values are parsed by the CSV loader.
+
+    - dir: Recursively scan a directory for files matching --pattern, up to
+      --depth levels deep. Each discovered file becomes a job.
+
+    - list: Convert an explicit list of --paths provided on the command
+      line.
+
+    Converter options (destination, chunking, pyramid settings, channels,
+    axes, and so on) are provided via the shared ome_zarr_options flags.
+    These flags are converted into OmeZarrConverter init kwargs via
+    build_ome_zarr_init_opts and applied as defaults for all jobs.
+
+    Examples:
+
+    \b
+      # CSV mode
+      bioio-batch-convert --mode csv --csv-file jobs.csv \\
+          --destination out --tbatch 1
+
+    \b
+      # Directory mode
+      bioio-batch-convert --mode dir --directory data --pattern "*.czi" \\
+          --depth 1 --destination out
+
+    \b
+      # List mode
+      bioio-batch-convert --mode list --paths a.ome.tiff b.ome.tiff \\
+          --destination out
     """
     try:
-        # Parse extra options
-        default_opts: Dict[str, Any] = parse_extra_opts(extra_opts)
+        # Map Click params → OmeZarrConverter kwargs, then coerce to a plain
+        # dict[str, Any] for BatchConverter's type signature.
+        init_opts_typed = build_ome_zarr_init_opts(**kwargs)
+        default_opts: Dict[str, Any] = dict(init_opts_typed)
 
         bc = BatchConverter(default_opts=default_opts)
 
-        mode_lower = mode.lower()
-        if mode_lower == "csv":
+        if mode.lower() == "csv":
             if csv_file is None:
                 raise click.BadParameter("--csv-file is required in csv mode")
             jobs = bc.from_csv(Path(csv_file))
-        elif mode_lower == "dir":
+        elif mode.lower() == "dir":
             if directory is None:
                 raise click.BadParameter("--directory is required in dir mode")
             jobs = bc.from_directory(
@@ -102,7 +119,7 @@ def main(
                 max_depth=depth,
                 pattern=pattern,
             )
-        else:  # list
+        else:
             if not paths:
                 raise click.BadParameter("--paths is required in list mode")
             jobs = bc.from_list(list(paths))
@@ -110,14 +127,7 @@ def main(
         click.echo(f"Discovered {len(jobs)} job(s), commencing conversion…")
         bc.run_jobs(jobs)
         click.echo("Batch conversion complete.")
-
-    except click.BadParameter:
+    except click.ClickException:
         raise
-    except KeyboardInterrupt:
-        raise click.Abort()
     except Exception as e:
         raise click.ClickException(f"Batch conversion failed: {e}")
-
-
-if __name__ == "__main__":
-    main()

--- a/bioio_conversion/bin/cli_convert.py
+++ b/bioio_conversion/bin/cli_convert.py
@@ -1,534 +1,59 @@
-from typing import Any, List, Optional, Sequence, Tuple, TypedDict, Union
+from typing import Any
 
 import click
-from bioio_ome_zarr.writers import Channel
-from bioio_ome_zarr.writers.ome_zarr_writer import MultiResolutionShapeSpec
-from click import Context, Parameter
 
 from ..converters.ome_zarr_converter import OmeZarrConverter
+from .ome_zarr_options import build_ome_zarr_init_opts, ome_zarr_options
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# TypedDict for converter init kwargs
-# ──────────────────────────────────────────────────────────────────────────────
-class OmeZarrInitOptions(TypedDict, total=False):
-    axes_names: List[str]
-    axes_types: List[str]
-    axes_units: List[Optional[str]]
-    destination: str
-    name: str
-    scenes: Union[int, List[int]]
-    tbatch: int
-    start_T_src: int
-    start_T_dest: int
-    level_shapes: MultiResolutionShapeSpec
-    num_levels: int
-    downsample_z: bool
-    chunk_shape: MultiResolutionShapeSpec
-    memory_target: int
-    shard_shape: MultiResolutionShapeSpec
-    dtype: str
-    channels: List[Channel]
-    physical_pixel_size: List[float]
-    zarr_format: int
-
-
-# ──────────────────────────────────────────────────────────────────────────────
-# ParamTypes
-# ──────────────────────────────────────────────────────────────────────────────
-
-
-class FloatListType(click.ParamType):
-    name = "float_list"
-
-    def convert(self, value: Any, param: Parameter, ctx: Context) -> Tuple[float, ...]:
-        text = str(value)
-        try:
-            floats: Tuple[float, ...] = tuple(float(x) for x in text.split(","))
-        except Exception:
-            self.fail(
-                f"{value!r} is not a valid float list.\n"
-                "Expected comma-separated floats.",
-                param,
-                ctx,
-            )
-        return floats
-
-
-class IntListType(click.ParamType):
-    name = "int_list"
-
-    def convert(self, value: Any, param: Parameter, ctx: Context) -> Tuple[int, ...]:
-        text = str(value)
-        try:
-            ints: Tuple[int, ...]
-            if text.strip() == "":
-                ints = tuple()
-            else:
-                ints = tuple(int(x) for x in text.split(","))
-        except Exception:
-            self.fail(
-                f"{value} is not a valid integer list. Example: (1, 1, 16, 256, 256)",
-                param,
-                ctx,
-            )
-        return ints
-
-
-class IntTupleListType(click.ParamType):
-    name = "int_tuple_list"
-
-    def convert(
-        self, value: Any, param: Parameter, ctx: Context
-    ) -> List[Tuple[int, ...]]:
-        text = str(value)
-        try:
-            int_tuples: List[Tuple[int, ...]]
-            if text.strip() == "":
-                int_tuples = []
-            else:
-                int_tuples = [
-                    tuple(int(x) for x in part.split(",")) for part in text.split(";")
-                ]
-        except Exception:
-            self.fail(
-                f"{value!r} is not a valid semicolon-separated list of int tuples. "
-                "Example: '1,1,16,256,256;1,1,16,128,128'",
-                param,
-                ctx,
-            )
-        return int_tuples
-
-
-class ScenesType(click.ParamType):
-    name = "scenes"
-
-    def convert(
-        self, value: Any, param: Parameter, ctx: Context
-    ) -> Union[int, List[int]]:
-        text = str(value).strip()
-        try:
-            parts = [int(x) for x in text.split(",")]
-        except Exception:
-            self.fail(
-                f"{value!r} is not a valid --scenes value. "
-                "Use a single index or comma-separated list (e.g. '0,2').",
-                param,
-                ctx,
-            )
-        return parts[0] if len(parts) == 1 else parts
-
-
-class StrListType(click.ParamType):
-    name = "str_list"
-
-    def convert(self, value: Any, param: Parameter, ctx: Context) -> List[str]:
-        return [c.strip() for c in str(value).split(",") if c.strip()]
-
-
-class BoolListType(click.ParamType):
-    """Parse comma-separated booleans like 'true,false,1,0,yes,no'."""
-
-    name = "bool_list"
-    TRUE = {"1", "true", "t", "yes", "y", "on"}
-    FALSE = {"0", "false", "f", "no", "n", "off"}
-
-    def convert(self, value: Any, param: Parameter, ctx: Context) -> Tuple[bool, ...]:
-        text = str(value)
-        try:
-            vals: Tuple[bool, ...]
-            if text.strip() == "":
-                vals = tuple()
-            else:
-                parsed: List[bool] = []
-                for tok in text.split(","):
-                    s = tok.strip().lower()
-                    if s in self.TRUE:
-                        parsed.append(True)
-                    elif s in self.FALSE:
-                        parsed.append(False)
-                    else:
-                        raise ValueError(s)
-                vals = tuple(parsed)
-        except Exception:
-            self.fail(
-                f"{value!r} is not a valid boolean list. Use true/false or 1/0.",
-                param,
-                ctx,
-            )
-        return vals
-
-
-def _get(seq: Optional[Sequence[Any]], idx: int, default: Any) -> Any:
-    return seq[idx] if seq is not None and idx < len(seq) else default
-
-
-def _build_channels(
-    labels: List[str],
-    colors: Optional[List[str]],
-    actives: Optional[Tuple[bool, ...]],
-    coefs: Optional[Tuple[float, ...]],
-    families: Optional[List[str]],
-    inverted: Optional[Tuple[bool, ...]],
-    w_min: Optional[Tuple[int, ...]],
-    w_max: Optional[Tuple[int, ...]],
-    w_start: Optional[Tuple[int, ...]],
-    w_end: Optional[Tuple[int, ...]],
-) -> List[Channel]:
-    channels: List[Channel] = []
-    # Determine if any non-required channel attributes were provided at all
-    any_optional = any(
-        v is not None
-        for v in (actives, coefs, families, inverted, w_min, w_max, w_start, w_end)
-    )
-
-    for i, label in enumerate(labels):
-        # Always supply minimal required args
-        base_color = _get(colors, i, "#FFFFFF")
-        ch_kwargs: dict = {"label": label, "color": base_color}
-
-        # Only pass optional kwargs if the user provided that group of values
-        if any_optional:
-            if actives is not None and i < len(actives):
-                ch_kwargs["active"] = bool(actives[i])
-            if coefs is not None and i < len(coefs):
-                ch_kwargs["coefficient"] = float(coefs[i])
-            if families is not None and i < len(families):
-                ch_kwargs["family"] = families[i]
-            if inverted is not None and i < len(inverted):
-                ch_kwargs["inverted"] = bool(inverted[i])
-
-            # Window: only include if any window tokens were provided;
-            # fill missing pieces with Channel defaults.
-            if any(v is not None for v in (w_min, w_max, w_start, w_end)):
-                ch_kwargs["window"] = {
-                    "min": _get(w_min, i, 0),
-                    "max": _get(w_max, i, 255),
-                    "start": _get(w_start, i, 0),
-                    "end": _get(w_end, i, 255),
-                }
-
-        channels.append(Channel(**ch_kwargs))
-    return channels
-
-
-class OptionalStrListType(click.ParamType):
-    """
-    Comma-separated strings where '', 'none', 'null' → None.
-
-    Example:
-      's,,um,um,um'        -> ['s', None, 'um', 'um', 'um']
-      'none,none,um'      -> [None, None, 'um']
-      's,null,um,um,um'   -> ['s', None, 'um', 'um', 'um']
-    """
-
-    name = "optional_str_list"
-    NONE_TOKENS = {"", "none", "null", "nil"}
-
-    def convert(
-        self, value: Any, param: Parameter, ctx: Context
-    ) -> List[Optional[str]]:
-        parts = [p.strip() for p in str(value).split(",")]
-        out: List[Optional[str]] = []
-        for p in parts:
-            if p.lower() in self.NONE_TOKENS:
-                out.append(None)
-            else:
-                out.append(p)
-        return out
-
-
-# ──────────────────────────────────────────────────────────────────────────────
-# CLI definition
-# ──────────────────────────────────────────────────────────────────────────────
 @click.command()
-@click.argument("source", type=click.Path(exists=True))
-@click.option(
-    "--destination",
-    "-d",
-    required=True,
-    type=click.Path(),
-    help="Output directory for .ome.zarr stores",
+@click.argument(
+    "source",
+    type=click.Path(exists=True),
 )
-@click.option(
-    "--name",
-    "-n",
-    default=None,
-    help="Base name for output stores (defaults to source stem)",
-)
-@click.option(
-    "--scenes",
-    "-s",
-    type=ScenesType(),
-    default=None,
-    help="Which scene(s) to export, e.g. '0' or '0,2'. Default: all",
-)
-@click.option(
-    "--tbatch", type=int, default=None, help="Number of timepoints per write batch"
-)
-@click.option(
-    "--start-t-src",
-    type=int,
-    default=None,
-    help="Source T index at which to begin reading (maps to writer.start_T_src)",
-)
-@click.option(
-    "--start-t-dest",
-    type=int,
-    default=None,
-    help="Destination T index at which to begin writing (maps to writer.start_T_dest)",
-)
-# --- multiscale control ---
-@click.option(
-    "--level-shapes",
-    type=IntTupleListType(),
-    default=None,
-    help=(
-        "Semicolon-separated per-level SHAPES (ints), level 0 first. "
-        "Each tuple length must match native axes. "
-        "Example: '2,3,5,512,512;2,3,5,256,256;2,3,5,128,128'. "
-        "If provided, overrides --num-levels/--downsample-z."
-    ),
-)
-@click.option(
-    "--num-levels",
-    type=int,
-    default=None,
-    help="Total multiscale levels (>=1). If provided (and --level-shapes not set), "
-    "build a half-pyramid: X/Y always 0.5^level; add --downsample-z to also "
-    "downsample Z when present.",
-)
-@click.option(
-    "--downsample-z",
-    is_flag=True,
-    default=False,
-    help="With --num-levels, also half Z per level when a Z axis exists.",
-)
-# --- chunking ---
-@click.option(
-    "--chunk-shape",
-    type=IntListType(),
-    default=None,
-    help="Single chunk shape tuple, e.g. '1,1,16,256,256'.",
-)
-@click.option(
-    "--chunk-shape-per-level",
-    type=IntTupleListType(),
-    default=None,
-    help="Per-level chunk shapes, e.g. '1,1,16,256,256;1,1,16,128,128'.",
-)
-@click.option(
-    "--shard-shape",
-    type=IntListType(),
-    default=None,
-    help="(Zarr v3) Single shard shape, e.g. '1,1,128,1024,1024'.",
-)
-@click.option(
-    "--shard-shape-per-level",
-    type=IntTupleListType(),
-    default=None,
-    help="(Zarr v3) Per-level shard shapes, semicolon-separated int tuples.",
-)
-@click.option(
-    "--memory-target",
-    type=int,
-    default=None,
-    help="generate and use per-level chunk shapes from this in-memory byte target.",
-)
-# --- metadata & writer ---
-@click.option("--dtype", default=None)
-@click.option("--physical-pixel-sizes", type=FloatListType(), default=None)
-@click.option(
-    "--zarr-format",
-    type=click.Choice(["2", "3"], case_sensitive=False),
-    default=None,  # Optional: let the writer default when omitted
-    help="Target Zarr format (2=NGFF 0.4, 3=NGFF 0.5). If None, use writer default ",
-)
-# --- Channel (full access) ---
-@click.option(
-    "--channel-labels",
-    type=StrListType(),
-    default=None,
-    help="Comma-separated channel labels. If provided, Channel[] will be built.",
-)
-@click.option(
-    "--channel-colors",
-    type=StrListType(),
-    default=None,
-    help="Comma-separated channel colors (e.g. '#FF00FF,red,#00FF00').",
-)
-@click.option(
-    "--channel-actives",
-    type=BoolListType(),
-    default=None,
-    help="Comma-separated booleans for channel visibility, e.g. 'true,false'.",
-)
-@click.option(
-    "--channel-coefficients",
-    type=FloatListType(),
-    default=None,
-    help="Comma-separated floats for coefficients, e.g. '1,0.8,1'.",
-)
-@click.option(
-    "--channel-families",
-    type=StrListType(),
-    default=None,
-    help="Comma-separated intensity families (e.g. 'linear,sRGB').",
-)
-@click.option(
-    "--channel-inverted",
-    type=BoolListType(),
-    default=None,
-    help="Comma-separated booleans for inversion flags.",
-)
-@click.option(
-    "--channel-window-min",
-    type=IntListType(),
-    default=None,
-    help="Comma-separated ints for window.min per channel.",
-)
-@click.option(
-    "--channel-window-max",
-    type=IntListType(),
-    default=None,
-    help="Comma-separated ints for window.max per channel.",
-)
-@click.option(
-    "--channel-window-start",
-    type=IntListType(),
-    default=None,
-    help="Comma-separated ints for window.start per channel.",
-)
-@click.option(
-    "--channel-window-end",
-    type=IntListType(),
-    default=None,
-    help="Comma-separated ints for window.end per channel.",
-)
-@click.option(
-    "--axes-names",
-    type=StrListType(),
-    default=None,
-    help="Comma-separated axis names to write. Must match native order.",
-)
-@click.option(
-    "--axes-types",
-    type=StrListType(),
-    default=None,
-    help="Comma-separated axis types (e.g. time,channel,space,...).",
-)
-@click.option(
-    "--axes-units",
-    type=OptionalStrListType(),
-    default=None,
-    help=(
-        "Comma-separated axis units. "
-        "Use blank or 'none' for missing. Example: 's,,um,um,um'."
-    ),
-)
-def main(
-    source: str,
-    destination: str,
-    name: Optional[str],
-    scenes: Optional[Union[int, List[int]]],
-    tbatch: Optional[int],
-    start_t_src: Optional[int],
-    start_t_dest: Optional[int],
-    level_shapes: Optional[List[Tuple[int, ...]]],
-    num_levels: Optional[int],
-    downsample_z: bool,
-    chunk_shape: Optional[Tuple[int, ...]],
-    chunk_shape_per_level: Optional[List[Tuple[int, ...]]],
-    shard_shape: Optional[Tuple[int, ...]],
-    shard_shape_per_level: Optional[List[Tuple[int, ...]]],
-    memory_target: Optional[int],
-    dtype: Optional[str],
-    physical_pixel_sizes: Optional[Tuple[float, ...]],
-    zarr_format: Optional[str],
-    channel_labels: Optional[List[str]],
-    channel_colors: Optional[List[str]],
-    channel_actives: Optional[Tuple[bool, ...]],
-    channel_coefficients: Optional[Tuple[float, ...]],
-    channel_families: Optional[List[str]],
-    channel_inverted: Optional[Tuple[bool, ...]],
-    channel_window_min: Optional[Tuple[int, ...]],
-    channel_window_max: Optional[Tuple[int, ...]],
-    channel_window_start: Optional[Tuple[int, ...]],
-    channel_window_end: Optional[Tuple[int, ...]],
-    axes_names: Optional[List[str]],
-    axes_types: Optional[List[str]],
-    axes_units: Optional[List[Optional[str]]],
-) -> None:
-    init_opts: OmeZarrInitOptions = {"destination": destination}
+@ome_zarr_options(require_destination=True)
+def main(source: str, **kwargs: dict[str, Any]) -> None:
+    """
+    Convert a single image file to OME-Zarr.
 
-    if zarr_format is not None:
-        init_opts["zarr_format"] = int(zarr_format)
-    if name is not None:
-        init_opts["name"] = name
-    if scenes is not None:
-        init_opts["scenes"] = scenes
-    if tbatch is not None:
-        init_opts["tbatch"] = tbatch
-    if start_t_src is not None:
-        init_opts["start_T_src"] = start_t_src
-    if start_t_dest is not None:
-        init_opts["start_T_dest"] = start_t_dest
-    if level_shapes and len(level_shapes) > 0:
-        init_opts["level_shapes"] = level_shapes
-    elif num_levels is not None:
-        init_opts["num_levels"] = num_levels
-        if downsample_z:
-            init_opts["downsample_z"] = True
-    if chunk_shape_per_level and len(chunk_shape_per_level) > 0:
-        init_opts["chunk_shape"] = chunk_shape_per_level
-    elif chunk_shape:
-        init_opts["chunk_shape"] = chunk_shape
+    SOURCE is the input image file (for example .czi, .ome.tiff, .nd2).
 
-    if shard_shape_per_level and len(shard_shape_per_level) > 0:
-        init_opts["shard_shape"] = shard_shape_per_level
-    elif shard_shape:
-        init_opts["shard_shape"] = shard_shape
+    All additional flags are shared OME-Zarr conversion options provided via
+    ome_zarr_options.
 
-    if memory_target is not None:
-        init_opts["memory_target"] = memory_target
-    if dtype is not None:
-        init_opts["dtype"] = dtype
-    if physical_pixel_sizes:
-        init_opts["physical_pixel_size"] = list(physical_pixel_sizes)
+    Examples:
 
-    # Channels (full access; use defaults when options omitted)
-    if channel_labels is not None and len(channel_labels) > 0:
-        init_opts["channels"] = _build_channels(
-            labels=channel_labels,
-            colors=channel_colors,
-            actives=channel_actives,
-            coefs=channel_coefficients,
-            families=channel_families,
-            inverted=channel_inverted,
-            w_min=channel_window_min,
-            w_max=channel_window_max,
-            w_start=channel_window_start,
-            w_end=channel_window_end,
-        )
+    \b
+      # Basic conversion
+      bioio-convert input.czi --destination out_dir
 
-    # Axis Control
-    if axes_names is not None:
-        init_opts["axes_names"] = axes_names
-    if axes_types is not None:
-        init_opts["axes_types"] = axes_types
-    if axes_units is not None:
-        init_opts["axes_units"] = axes_units
-
+    \b
+      # With pyramid and chunk control
+      bioio-convert input.czi \\
+          --destination out_dir \\
+          --num-levels 3 \\
+          --downsample-z \\
+          --chunk-shape 1,1,16,256,256
+    """
     try:
-        conv = OmeZarrConverter(source=source, **init_opts)
-        conv.convert()
+        # Map Click params → OmeZarrConverter kwargs
+        init_opts = build_ome_zarr_init_opts(**kwargs)
+
+        # Execute conversion
+        OmeZarrConverter(source=source, **init_opts).convert()
+
     except FileExistsError as e:
+        # Surface common, expected filesystem issues clearly
         raise click.ClickException(str(e))
+
     except KeyboardInterrupt:
+        # Clean CTRL+C handling
         raise click.Abort()
+
+    except click.ClickException:
+        # Preserve Click's formatted errors
+        raise
+
     except Exception as e:
+        # Catch-all safety net with clean CLI formatting
         raise click.ClickException(f"Conversion failed: {e}")
-
-
-if __name__ == "__main__":
-    main()

--- a/bioio_conversion/bin/cli_convert.py
+++ b/bioio_conversion/bin/cli_convert.py
@@ -36,24 +36,14 @@ def main(source: str, **kwargs: dict[str, Any]) -> None:
           --chunk-shape 1,1,16,256,256
     """
     try:
-        # Map Click params → OmeZarrConverter kwargs
         init_opts = build_ome_zarr_init_opts(**kwargs)
-
-        # Execute conversion
         OmeZarrConverter(source=source, **init_opts).convert()
 
-    except FileExistsError as e:
-        # Surface common, expected filesystem issues clearly
-        raise click.ClickException(str(e))
-
     except KeyboardInterrupt:
-        # Clean CTRL+C handling
         raise click.Abort()
 
     except click.ClickException:
-        # Preserve Click's formatted errors
         raise
 
     except Exception as e:
-        # Catch-all safety net with clean CLI formatting
         raise click.ClickException(f"Conversion failed: {e}")

--- a/bioio_conversion/bin/cli_convert.py
+++ b/bioio_conversion/bin/cli_convert.py
@@ -12,7 +12,7 @@ from .ome_zarr_options import build_ome_zarr_init_opts, ome_zarr_options
     type=click.Path(exists=True),
 )
 @ome_zarr_options(require_destination=True)
-def main(source: str, **kwargs: dict[str, Any]) -> None:
+def main(source: str, **kwargs: Any) -> None:
     """
     Convert a single image file to OME-Zarr.
 

--- a/bioio_conversion/bin/ome_zarr_options.py
+++ b/bioio_conversion/bin/ome_zarr_options.py
@@ -1,0 +1,726 @@
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypedDict,
+    TypeVar,
+    Union,
+    cast,
+)
+
+import click
+from bioio_ome_zarr.writers import Channel
+from bioio_ome_zarr.writers.ome_zarr_writer import MultiResolutionShapeSpec
+from click import Context, Parameter
+
+
+class OmeZarrInitOptions(TypedDict, total=False):
+    """
+    The subset of `OmeZarrConverter.__init__` kwargs that can be provided
+    by the CLI.
+    """
+
+    axes_names: List[str]
+    axes_types: List[str]
+    axes_units: List[Optional[str]]
+    destination: str
+    name: str
+    scenes: Union[int, List[int]]
+    tbatch: int
+    start_T_src: int
+    start_T_dest: int
+
+    # pyramid / multiscale
+    level_shapes: MultiResolutionShapeSpec
+    num_levels: int
+    downsample_z: bool
+
+    # chunking / sharding
+    chunk_shape: MultiResolutionShapeSpec
+    memory_target: int
+    shard_shape: MultiResolutionShapeSpec
+
+    # data / metadata
+    dtype: str
+    channels: List[Channel]
+    physical_pixel_size: List[float]
+    zarr_format: int
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ParamTypes
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class FloatListType(click.ParamType):
+    """Parse '1.0,2.0,3.5' -> (1.0, 2.0, 3.5)"""
+
+    name = "float_list"
+
+    def convert(
+        self,
+        value: Any,
+        param: Parameter,
+        ctx: Context,
+    ) -> Tuple[float, ...]:
+        text = str(value)
+        try:
+            return tuple(float(x) for x in text.split(","))
+        except Exception:
+            self.fail(
+                f"{value!r} is not a valid float list (comma-separated).",
+                param,
+                ctx,
+            )
+            # For type checkers: self.fail always raises.
+            assert False, "unreachable"
+
+
+class IntListType(click.ParamType):
+    """Parse '1,2,3' -> (1, 2, 3). Empty string -> ()."""
+
+    name = "int_list"
+
+    def convert(
+        self,
+        value: Any,
+        param: Parameter,
+        ctx: Context,
+    ) -> Tuple[int, ...]:
+        text = str(value).strip()
+        try:
+            return tuple() if text == "" else tuple(int(x) for x in text.split(","))
+        except Exception:
+            self.fail(
+                f"{value!r} is not a valid int list (comma-separated).",
+                param,
+                ctx,
+            )
+            assert False, "unreachable"
+
+
+class IntTupleListType(click.ParamType):
+    """
+    Parse per-level tuples like:
+        '1,1,16,256,256;1,1,16,128,128'
+    ->  [(1,1,16,256,256), (1,1,16,128,128)]
+
+    Empty string -> [].
+    """
+
+    name = "int_tuple_list"
+
+    def convert(
+        self,
+        value: Any,
+        param: Parameter,
+        ctx: Context,
+    ) -> List[Tuple[int, ...]]:
+        text = str(value).strip()
+        try:
+            return (
+                []
+                if text == ""
+                else [
+                    tuple(int(x) for x in part.split(",")) for part in text.split(";")
+                ]
+            )
+        except Exception:
+            self.fail(
+                f"{value!r} is not a valid ';' list of int tuples.",
+                param,
+                ctx,
+            )
+            assert False, "unreachable"
+
+
+class ScenesType(click.ParamType):
+    """
+    Parse scenes selection:
+      '0'   -> 0
+      '0,2' -> [0, 2]
+    """
+
+    name = "scenes"
+
+    def convert(
+        self,
+        value: Any,
+        param: Parameter,
+        ctx: Context,
+    ) -> Union[int, List[int]]:
+        text = str(value).strip()
+        try:
+            parts = [int(x) for x in text.split(",")]
+        except Exception:
+            self.fail(
+                f"{value!r} is not a valid --scenes value (e.g. '0' or '0,2').",
+                param,
+                ctx,
+            )
+            assert False, "unreachable"
+        return parts[0] if len(parts) == 1 else parts
+
+
+class StrListType(click.ParamType):
+    """
+    Parse 'a,b,c' -> ['a','b','c'] (strips whitespace, drops empty tokens).
+    """
+
+    name = "str_list"
+
+    def convert(
+        self,
+        value: Any,
+        param: Parameter,
+        ctx: Context,
+    ) -> List[str]:
+        return [c.strip() for c in str(value).split(",") if c.strip()]
+
+
+class BoolListType(click.ParamType):
+    """
+    Parse comma-separated booleans:
+
+      'true,false,1,0,yes,no,on,off'
+      -> (True, False, True, False, True, False, True, False)
+    """
+
+    name = "bool_list"
+
+    TRUE = {"1", "true", "t", "yes", "y", "on"}
+    FALSE = {"0", "false", "f", "no", "n", "off"}
+
+    def convert(
+        self,
+        value: Any,
+        param: Parameter,
+        ctx: Context,
+    ) -> Tuple[bool, ...]:
+        text = str(value).strip()
+        if text == "":
+            return tuple()
+
+        out: List[bool] = []
+        for tok in text.split(","):
+            s = tok.strip().lower()
+            if s in self.TRUE:
+                out.append(True)
+            elif s in self.FALSE:
+                out.append(False)
+            else:
+                self.fail(
+                    f"{value!r} is not a valid boolean list.",
+                    param,
+                    ctx,
+                )
+                assert False, "unreachable"
+        return tuple(out)
+
+
+class OptionalStrListType(click.ParamType):
+    """
+    Parse comma-separated strings where blanks/'none'/'null' become None.
+
+    Example:
+      's,,um,um,um' -> ['s', None, 'um', 'um', 'um']
+    """
+
+    name = "optional_str_list"
+    NONE_TOKENS = {"", "none", "null", "nil"}
+
+    def convert(
+        self,
+        value: Any,
+        param: Parameter,
+        ctx: Context,
+    ) -> List[Optional[str]]:
+        parts = [p.strip() for p in str(value).split(",")]
+        out: List[Optional[str]] = []
+        for p in parts:
+            out.append(None if p.lower() in self.NONE_TOKENS else p)
+        return out
+
+
+def _get(
+    seq: Optional[Sequence[Any]],
+    idx: int,
+    default: Any,
+) -> Any:
+    """Safe index helper for per-channel option lists."""
+    return seq[idx] if seq is not None and idx < len(seq) else default
+
+
+def build_channels(
+    labels: List[str],
+    colors: Optional[List[str]],
+    actives: Optional[Tuple[bool, ...]],
+    coefs: Optional[Tuple[float, ...]],
+    families: Optional[List[str]],
+    inverted: Optional[Tuple[bool, ...]],
+    w_min: Optional[Tuple[int, ...]],
+    w_max: Optional[Tuple[int, ...]],
+    w_start: Optional[Tuple[int, ...]],
+    w_end: Optional[Tuple[int, ...]],
+) -> List[Channel]:
+    """
+    Build `Channel[]` from per-channel CLI options.
+    """
+    channels: List[Channel] = []
+
+    any_optional = any(
+        v is not None
+        for v in (
+            actives,
+            coefs,
+            families,
+            inverted,
+            w_min,
+            w_max,
+            w_start,
+            w_end,
+        )
+    )
+
+    for i, label in enumerate(labels):
+        ch_kwargs: Dict[str, Any] = {
+            "label": label,
+            "color": _get(colors, i, "#FFFFFF"),
+        }
+
+        if any_optional:
+            # Only apply optional fields where values were supplied
+            if actives is not None and i < len(actives):
+                ch_kwargs["active"] = bool(actives[i])
+            if coefs is not None and i < len(coefs):
+                ch_kwargs["coefficient"] = float(coefs[i])
+            if families is not None and i < len(families):
+                ch_kwargs["family"] = families[i]
+            if inverted is not None and i < len(inverted):
+                ch_kwargs["inverted"] = bool(inverted[i])
+
+            if any(v is not None for v in (w_min, w_max, w_start, w_end)):
+                ch_kwargs["window"] = {
+                    "min": _get(w_min, i, 0),
+                    "max": _get(w_max, i, 255),
+                    "start": _get(w_start, i, 0),
+                    "end": _get(w_end, i, 255),
+                }
+
+        channels.append(Channel(**ch_kwargs))
+
+    return channels
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def ome_zarr_options(
+    *,
+    require_destination: bool,
+) -> Callable[[F], F]:
+    """
+    Attach the shared OME-Zarr converter flags to a Click command.
+
+    These options are translated into `OmeZarrConverter.__init__` kwargs
+    via `build_ome_zarr_init_opts(...)` and can be reused across CLIs
+    (single-file or batch).
+    """
+
+    def _decorator(fn: F) -> F:
+        opts = [
+            # ── Axis controls ────────────────────────────────────────────
+            click.option(
+                "--axes-names",
+                type=StrListType(),
+                default=None,
+                help=(
+                    "Comma-separated axis names to write, in native axis "
+                    "order. Example: 't,c,z,y,x'. If omitted, use names "
+                    "derived from the reader."
+                ),
+            ),
+            click.option(
+                "--axes-types",
+                type=StrListType(),
+                default=None,
+                help=(
+                    "Comma-separated axis semantic types, one per axis name. "
+                    "Typical values include 'time', 'channel', and 'space'. "
+                    "Example: 'time,channel,space,space,space'."
+                ),
+            ),
+            click.option(
+                "--axes-units",
+                type=OptionalStrListType(),
+                default=None,
+                help=(
+                    "Comma-separated axis units, in the same order as "
+                    "--axes-names. Use blank or 'none'/'null' for missing "
+                    "units. Example for (t,c,z,y,x): 's,,um,um,um'."
+                ),
+            ),
+            # ── Channel controls (only used when --channel-labels is set) ─
+            click.option(
+                "--channel-labels",
+                type=StrListType(),
+                default=None,
+                help=(
+                    "Comma-separated channel labels. If provided, a Channel[] "
+                    "definition is built and written into the OME-Zarr "
+                    "metadata. Example: 'DAPI,GFP,TRITC'."
+                ),
+            ),
+            click.option(
+                "--channel-colors",
+                type=StrListType(),
+                default=None,
+                help=(
+                    "Comma-separated channel colors matching --channel-labels. "
+                    "Values may be CSS color names or hex codes. Example: "
+                    "'#0000FF,#00FF00,#FF0000'."
+                ),
+            ),
+            click.option(
+                "--channel-actives",
+                type=BoolListType(),
+                default=None,
+                help=(
+                    "Comma-separated booleans controlling channel visibility. "
+                    "Example: 'true,true,false' to hide the third channel."
+                ),
+            ),
+            click.option(
+                "--channel-coefficients",
+                type=FloatListType(),
+                default=None,
+                help=(
+                    "Comma-separated floats for per-channel intensity "
+                    "coefficients. Example: '1,0.8,1.2'."
+                ),
+            ),
+            click.option(
+                "--channel-families",
+                type=StrListType(),
+                default=None,
+                help=(
+                    "Comma-separated intensity families per channel "
+                    "(e.g. 'linear', 'sRGB'). Example: 'linear,sRGB,sRGB'."
+                ),
+            ),
+            click.option(
+                "--channel-inverted",
+                type=BoolListType(),
+                default=None,
+                help=(
+                    "Comma-separated booleans for inverted display per channel. "
+                    "Example: 'false,true,false'."
+                ),
+            ),
+            click.option(
+                "--channel-window-min",
+                type=IntListType(),
+                default=None,
+                help=(
+                    "Comma-separated ints for window.min per channel. Only "
+                    "used when any window value is provided."
+                ),
+            ),
+            click.option(
+                "--channel-window-max",
+                type=IntListType(),
+                default=None,
+                help=(
+                    "Comma-separated ints for window.max per channel. Only "
+                    "used when any window value is provided."
+                ),
+            ),
+            click.option(
+                "--channel-window-start",
+                type=IntListType(),
+                default=None,
+                help=(
+                    "Comma-separated ints for window.start per channel. Only "
+                    "used when any window value is provided."
+                ),
+            ),
+            click.option(
+                "--channel-window-end",
+                type=IntListType(),
+                default=None,
+                help=(
+                    "Comma-separated ints for window.end per channel. Only "
+                    "used when any window value is provided."
+                ),
+            ),
+            # ── Data / metadata ───────────────────────────────────────────
+            click.option(
+                "--zarr-format",
+                type=click.Choice(["2", "3"], case_sensitive=False),
+                default=None,
+                help=(
+                    "Target Zarr format: '2' ≈ NGFF 0.4, '3' ≈ NGFF 0.5. "
+                    "If omitted, use the writer's default."
+                ),
+            ),
+            click.option(
+                "--physical-pixel-sizes",
+                type=FloatListType(),
+                default=None,
+                help=(
+                    "Comma-separated physical pixel sizes per axis, in the "
+                    "same order as --axes-names. Example (t,c,z,y,x): "
+                    "'1.0,1.0,0.3,0.108,0.108'. If omitted, use pixel sizes "
+                    "from the source metadata when available."
+                ),
+            ),
+            click.option(
+                "--dtype",
+                default=None,
+                help=(
+                    "Override output dtype (e.g. 'uint8', 'uint16', 'float32'). "
+                    "If omitted, the reader's native dtype is used."
+                ),
+            ),
+            # ── Chunking / sharding (advanced) ────────────────────────────
+            click.option(
+                "--memory-target",
+                type=int,
+                default=None,
+                help=(
+                    "Advanced: approximate in-memory byte budget to derive "
+                    "per-level chunk shapes. If set, the writer computes "
+                    "chunk shapes from this target (unless explicit "
+                    "--chunk-shape/--chunk-shape-per-level are given)."
+                ),
+            ),
+            click.option(
+                "--chunk-shape",
+                type=IntListType(),
+                default=None,
+                help=(
+                    "Advanced: single chunk shape tuple, one int per axis. "
+                    "Example: '1,1,16,256,256'. Applies to all pyramid levels "
+                    "unless --chunk-shape-per-level is provided."
+                ),
+            ),
+            click.option(
+                "--chunk-shape-per-level",
+                type=IntTupleListType(),
+                default=None,
+                help=(
+                    "Advanced: per-level chunk shapes, level 0 first. "
+                    "Semicolon-separated int tuples, each matching the number "
+                    "of axes. Example: '1,1,16,256,256;1,1,16,128,128'. "
+                    "Overrides --chunk-shape and --memory-target."
+                ),
+            ),
+            click.option(
+                "--shard-shape",
+                type=IntListType(),
+                default=None,
+                help=(
+                    "Advanced (Zarr v3): single shard shape tuple, one int per "
+                    "axis. Example: '1,1,128,1024,1024'. Applies to all "
+                    "levels unless --shard-shape-per-level is provided."
+                ),
+            ),
+            click.option(
+                "--shard-shape-per-level",
+                type=IntTupleListType(),
+                default=None,
+                help=(
+                    "Advanced (Zarr v3): per-level shard shapes, level 0 first. "
+                    "Semicolon-separated int tuples, e.g. "
+                    "'1,1,128,1024,1024;1,1,128,512,512'. Overrides "
+                    "--shard-shape."
+                ),
+            ),
+            # ── Pyramid / multiscale ──────────────────────────────────────
+            click.option(
+                "--num-levels",
+                type=int,
+                default=None,
+                help=(
+                    "Total number of multiscale levels (>=1). If set (and "
+                    "--level-shapes is not provided), the writer builds a half "
+                    "pyramid in X/Y (and optionally Z with --downsample-z)."
+                ),
+            ),
+            click.option(
+                "--downsample-z",
+                is_flag=True,
+                default=False,
+                help=(
+                    "With --num-levels, also half the Z dimension at each "
+                    "pyramid level when a Z axis exists."
+                ),
+            ),
+            click.option(
+                "--level-shapes",
+                type=IntTupleListType(),
+                default=None,
+                help=(
+                    "Semicolon-separated per-level SHAPES (ints), level 0 "
+                    "first. Each tuple length must match the number of axes. "
+                    "Example: '2,3,5,512,512;2,3,5,256,256;2,3,5,128,128'. If "
+                    "provided, overrides --num-levels and --downsample-z."
+                ),
+            ),
+            # ── Job slicing / scene selection ─────────────────────────────
+            click.option(
+                "--tbatch",
+                type=int,
+                default=None,
+                help=(
+                    "Number of timepoints per write batch. Smaller batches "
+                    "reduce memory usage at the cost of more I/O overhead."
+                ),
+            ),
+            click.option(
+                "--start-t-src",
+                type=int,
+                default=None,
+                help=(
+                    "Source T index at which to begin reading (0-based). Maps "
+                    "to writer.start_T_src."
+                ),
+            ),
+            click.option(
+                "--start-t-dest",
+                type=int,
+                default=None,
+                help=(
+                    "Destination T index at which to begin writing (0-based). "
+                    "Maps to writer.start_T_dest."
+                ),
+            ),
+            click.option(
+                "--scenes",
+                "-s",
+                type=ScenesType(),
+                default=None,
+                help=(
+                    "Which scene(s) to export, e.g. '0' or '0,2'. Default: all "
+                    "scenes in the source."
+                ),
+            ),
+            # ── Locational ─────────────────────────────
+            click.option(
+                "--name",
+                "-n",
+                default=None,
+                help=(
+                    "Base name for output stores (e.g. the group name inside "
+                    "the destination directory). If omitted, a default is "
+                    "derived from the input or CSV row."
+                ),
+            ),
+            click.option(
+                "--destination",
+                "-d",
+                required=require_destination,
+                type=click.Path(),
+                help=(
+                    "Output directory in which OME-Zarr stores will be created. "
+                    "In batch mode, all jobs write under this directory."
+                ),
+            ),
+        ]
+
+        for opt in reversed(opts):
+            fn = cast(F, opt(fn))
+        return fn
+
+    return _decorator
+
+
+def build_ome_zarr_init_opts(**kwargs: Any) -> OmeZarrInitOptions:
+    """
+    Convert Click parameters into `OmeZarrConverter(...)` init kwargs.
+    """
+    init_opts: OmeZarrInitOptions = {}
+
+    destination = kwargs.get("destination")
+    if destination is not None:
+        init_opts["destination"] = destination
+
+    zarr_format = kwargs.get("zarr_format")
+    if zarr_format is not None:
+        init_opts["zarr_format"] = int(zarr_format)
+
+    # Direct pass-through options (same key in click + converter)
+    if kwargs.get("name") is not None:
+        init_opts["name"] = kwargs["name"]
+    if kwargs.get("scenes") is not None:
+        init_opts["scenes"] = kwargs["scenes"]
+    if kwargs.get("tbatch") is not None:
+        init_opts["tbatch"] = kwargs["tbatch"]
+
+    # Click uses snake_case; converter uses start_T_* keys
+    if kwargs.get("start_t_src") is not None:
+        init_opts["start_T_src"] = kwargs["start_t_src"]
+    if kwargs.get("start_t_dest") is not None:
+        init_opts["start_T_dest"] = kwargs["start_t_dest"]
+
+    # Multiscale: explicit level_shapes overrides derived pyramids
+    level_shapes = kwargs.get("level_shapes")
+    num_levels = kwargs.get("num_levels")
+    downsample_z = kwargs.get("downsample_z", False)
+
+    if level_shapes:
+        init_opts["level_shapes"] = level_shapes
+    elif num_levels is not None:
+        init_opts["num_levels"] = num_levels
+        if downsample_z:
+            init_opts["downsample_z"] = True
+
+    # Chunk/shard: normalize per-level vs single tuple
+    if kwargs.get("chunk_shape_per_level"):
+        init_opts["chunk_shape"] = kwargs["chunk_shape_per_level"]
+    elif kwargs.get("chunk_shape"):
+        init_opts["chunk_shape"] = kwargs["chunk_shape"]
+
+    if kwargs.get("shard_shape_per_level"):
+        init_opts["shard_shape"] = kwargs["shard_shape_per_level"]
+    elif kwargs.get("shard_shape"):
+        init_opts["shard_shape"] = kwargs["shard_shape"]
+
+    if kwargs.get("memory_target") is not None:
+        init_opts["memory_target"] = kwargs["memory_target"]
+    if kwargs.get("dtype") is not None:
+        init_opts["dtype"] = kwargs["dtype"]
+
+    pps = kwargs.get("physical_pixel_sizes")
+    if pps:
+        init_opts["physical_pixel_size"] = list(pps)
+
+    # Channels: only build when labels are provided
+    channel_labels = kwargs.get("channel_labels")
+    if channel_labels:
+        init_opts["channels"] = build_channels(
+            labels=channel_labels,
+            colors=kwargs.get("channel_colors"),
+            actives=kwargs.get("channel_actives"),
+            coefs=kwargs.get("channel_coefficients"),
+            families=kwargs.get("channel_families"),
+            inverted=kwargs.get("channel_inverted"),
+            w_min=kwargs.get("channel_window_min"),
+            w_max=kwargs.get("channel_window_max"),
+            w_start=kwargs.get("channel_window_start"),
+            w_end=kwargs.get("channel_window_end"),
+        )
+
+    # Axes
+    if kwargs.get("axes_names") is not None:
+        init_opts["axes_names"] = kwargs["axes_names"]
+    if kwargs.get("axes_types") is not None:
+        init_opts["axes_types"] = kwargs["axes_types"]
+    if kwargs.get("axes_units") is not None:
+        init_opts["axes_units"] = kwargs["axes_units"]
+
+    return init_opts

--- a/bioio_conversion/bin/ome_zarr_options.py
+++ b/bioio_conversion/bin/ome_zarr_options.py
@@ -31,8 +31,8 @@ class OmeZarrInitOptions(TypedDict, total=False):
     name: str
     scenes: Union[int, List[int]]
     tbatch: int
-    start_T_src: int
-    start_T_dest: int
+    start_t_src: int
+    start_t_dest: int
 
     # pyramid / multiscale
     level_shapes: MultiResolutionShapeSpec
@@ -586,7 +586,7 @@ def ome_zarr_options(
                 default=None,
                 help=(
                     "Source T index at which to begin reading (0-based). Maps "
-                    "to writer.start_T_src."
+                    "to writer.start_t_src."
                 ),
             ),
             click.option(
@@ -595,7 +595,7 @@ def ome_zarr_options(
                 default=None,
                 help=(
                     "Destination T index at which to begin writing (0-based). "
-                    "Maps to writer.start_T_dest."
+                    "Maps to writer.start_t_dest."
                 ),
             ),
             click.option(
@@ -659,12 +659,10 @@ def build_ome_zarr_init_opts(**kwargs: Any) -> OmeZarrInitOptions:
         init_opts["scenes"] = kwargs["scenes"]
     if kwargs.get("tbatch") is not None:
         init_opts["tbatch"] = kwargs["tbatch"]
-
-    # Click uses snake_case; converter uses start_T_* keys
     if kwargs.get("start_t_src") is not None:
-        init_opts["start_T_src"] = kwargs["start_t_src"]
+        init_opts["start_t_src"] = kwargs["start_t_src"]
     if kwargs.get("start_t_dest") is not None:
-        init_opts["start_T_dest"] = kwargs["start_t_dest"]
+        init_opts["start_t_dest"] = kwargs["start_t_dest"]
 
     # Multiscale: explicit level_shapes overrides derived pyramids
     level_shapes = kwargs.get("level_shapes")

--- a/bioio_conversion/bin/ome_zarr_options.py
+++ b/bioio_conversion/bin/ome_zarr_options.py
@@ -121,18 +121,18 @@ class IntTupleListType(click.ParamType):
         ctx: Context,
     ) -> List[Tuple[int, ...]]:
         text = str(value).strip()
-
         if text == "":
             return []
 
         try:
             return [tuple(int(x) for x in part.split(",")) for part in text.split(";")]
         except Exception:
-            self.fail(
-                f"{value!r} is not a valid ';' list of int tuples.",
-                param,
-                ctx,
+            message = (
+                f"{value!r} is not a valid list of int tuples separated by "
+                "semicolons. Example: "
+                "'1,1,16,256,256;1,1,16,128,128'."
             )
+            self.fail(message, param, ctx)
             raise AssertionError("unreachable")
 
 
@@ -155,11 +155,11 @@ class ScenesType(click.ParamType):
         try:
             parts = [int(x) for x in text.split(",")]
         except Exception:
-            self.fail(
-                f"{value!r} is not a valid --scenes value (e.g. '0' or '0,2').",
-                param,
-                ctx,
+            message = (
+                f"{value!r} is not a valid --scenes value. Use a single index "
+                "like 0 or a comma-separated list like 0,2."
             )
+            self.fail(message, param, ctx)
             raise AssertionError("unreachable")
 
         return parts[0] if len(parts) == 1 else parts

--- a/bioio_conversion/bin/ome_zarr_options.py
+++ b/bioio_conversion/bin/ome_zarr_options.py
@@ -121,21 +121,19 @@ class IntTupleListType(click.ParamType):
         ctx: Context,
     ) -> List[Tuple[int, ...]]:
         text = str(value).strip()
+
+        if text == "":
+            return []
+
         try:
-            return (
-                []
-                if text == ""
-                else [
-                    tuple(int(x) for x in part.split(",")) for part in text.split(";")
-                ]
-            )
+            return [tuple(int(x) for x in part.split(",")) for part in text.split(";")]
         except Exception:
             self.fail(
                 f"{value!r} is not a valid ';' list of int tuples.",
                 param,
                 ctx,
             )
-            assert False, "unreachable"
+            raise AssertionError("unreachable")
 
 
 class ScenesType(click.ParamType):
@@ -162,7 +160,8 @@ class ScenesType(click.ParamType):
                 param,
                 ctx,
             )
-            assert False, "unreachable"
+            raise AssertionError("unreachable")
+
         return parts[0] if len(parts) == 1 else parts
 
 

--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -45,8 +45,8 @@ class OmeZarrConverter:
         num_levels: Optional[int] = None,
         downsample_z: bool = False,
         memory_target: Optional[int] = None,
-        start_T_src: Optional[int] = None,
-        start_T_dest: Optional[int] = None,
+        start_t_src: Optional[int] = None,
+        start_t_dest: Optional[int] = None,
         tbatch: Optional[int] = None,
         dtype: Optional[Union[str, np.dtype]] = None,
         auto_dask_cluster: bool = False,
@@ -120,10 +120,10 @@ class OmeZarrConverter:
             If set (bytes), suggests a single chunk shape derived from level-0 shape
             and ``dtype`` via ``chunk_size_from_memory_target``. Writer may reuse or
             adjust per level.
-        start_T_src : Optional[int]
+        start_t_src : Optional[int]
             Source T index at which to begin reading from the BioImage. Default: use
             writer default.
-        start_T_dest : Optional[int]
+        start_t_dest : Optional[int]
             Destination T index at which to begin writing into the store. Default:
             use writer default.
         tbatch : Optional[int]
@@ -185,8 +185,8 @@ class OmeZarrConverter:
         self._helper_memory_target_bytes = (
             None if memory_target is None else memory_target
         )
-        self._start_T_src = start_T_src
-        self._start_T_dest = start_T_dest
+        self._start_t_src = start_t_src
+        self._start_t_dest = start_t_dest
         self._tbatch = None if tbatch is None else tbatch
 
     # -------------------------------------------------------------------------
@@ -422,16 +422,16 @@ class OmeZarrConverter:
 
             # (8) Write
             has_t = "t" in axis_names
-            T_total = int(getattr(r.dims, "T", 1)) if has_t else 1
+            t_total = int(getattr(r.dims, "T", 1)) if has_t else 1
 
-            if has_t and T_total > 1:
+            if has_t and t_total > 1:
                 kwargs: Dict[str, Any] = {"data": data_all}
-                if self._start_T_src is not None:
-                    kwargs["start_T_src"] = self._start_T_src
-                if self._start_T_dest is not None:
-                    kwargs["start_T_dest"] = self._start_T_dest
+                if self._start_t_src is not None:
+                    kwargs["start_T_src"] = self._start_t_src
+                if self._start_t_dest is not None:
+                    kwargs["start_T_dest"] = self._start_t_dest
                 kwargs["total_T"] = (
-                    self._tbatch if self._tbatch is not None else T_total
+                    self._tbatch if self._tbatch is not None else t_total
                 )
                 writer.write_timepoints(**kwargs)
             else:

--- a/bioio_conversion/tests/test_cli_batch_conversion.py
+++ b/bioio_conversion/tests/test_cli_batch_conversion.py
@@ -21,15 +21,15 @@ from .conftest import LOCAL_RESOURCES_DIR
         ([], ["Missing option", "--mode"]),
         (
             ["--mode", "list", "--destination", "OUTDIR"],
-            ["--paths is required in list mode"],
+            ["At least one --paths is required when --mode list"],
         ),
         (
             ["--mode", "dir", "--destination", "OUTDIR"],
-            ["--directory is required in dir mode"],
+            ["--directory/--dir is required when --mode dir"],
         ),
         (
             ["--mode", "csv", "--destination", "OUTDIR"],
-            ["--csv-file is required in csv mode"],
+            ["--csv-file is required when --mode csv"],
         ),
     ],
     ids=[
@@ -44,14 +44,11 @@ def test_batch_cli_contract_errors(
     argv: list[str],
     expected_substrings: list[str],
 ) -> None:
-    # Arrange
     runner = CliRunner()
     resolved_argv = [str(tmp_path) if a == "OUTDIR" else a for a in argv]
 
-    # Act
     result = runner.invoke(batch_main, resolved_argv)
 
-    # Assert
     assert result.exit_code != 0, result.output
     for s in expected_substrings:
         assert s in result.output, result.output
@@ -143,12 +140,6 @@ def test_batch_cli_csv_mode(tmp_path: pathlib.Path) -> None:
                     "tbatch": "1",
                 }
             )
-
-    # Clean any existing outputs
-    for fn in ["s_1_t_1_c_1_z_1.ome.tiff", "s_3_t_1_c_3_z_5.ome.tiff"]:
-        out_path = out_dir / f"{pathlib.Path(fn).stem}.ome.zarr"
-        if out_path.exists():
-            shutil.rmtree(out_path)
 
     # Act
     result = runner.invoke(

--- a/bioio_conversion/tests/test_cli_batch_conversion.py
+++ b/bioio_conversion/tests/test_cli_batch_conversion.py
@@ -7,53 +7,106 @@ from bioio import BioImage
 from click.testing import CliRunner
 from numpy.testing import assert_array_equal
 
-from bioio_conversion.bin.cli_batch_convert import main
+from bioio_conversion.bin.cli_batch_convert import main as batch_main
 
 from .conftest import LOCAL_RESOURCES_DIR
 
 
+# ---------------------------------------------------------------------
+# Contract tests
+# ---------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "argv, expected_substrings",
+    [
+        ([], ["Missing option", "--mode"]),
+        (
+            ["--mode", "list", "--destination", "OUTDIR"],
+            ["--paths is required in list mode"],
+        ),
+        (
+            ["--mode", "dir", "--destination", "OUTDIR"],
+            ["--directory is required in dir mode"],
+        ),
+        (
+            ["--mode", "csv", "--destination", "OUTDIR"],
+            ["--csv-file is required in csv mode"],
+        ),
+    ],
+    ids=[
+        "missing-mode",
+        "list-missing-paths",
+        "dir-missing-directory",
+        "csv-missing-csv-file",
+    ],
+)
+def test_batch_cli_contract_errors(
+    tmp_path: pathlib.Path,
+    argv: list[str],
+    expected_substrings: list[str],
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    resolved_argv = [str(tmp_path) if a == "OUTDIR" else a for a in argv]
+
+    # Act
+    result = runner.invoke(batch_main, resolved_argv)
+
+    # Assert
+    assert result.exit_code != 0, result.output
+    for s in expected_substrings:
+        assert s in result.output, result.output
+
+
+# ---------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------
 @pytest.mark.parametrize(
     "filename, scene_index",
     [
         ("s_1_t_1_c_1_z_1.ome.tiff", 0),
         ("s_3_t_1_c_3_z_5.ome.tiff", 2),
     ],
-    ids=["list-file-scene0", "list-file-scene2"],
+    ids=["batch-list-scene0", "batch-list-scene2"],
 )
 def test_batch_cli_list_mode(
     tmp_path: pathlib.Path, filename: str, scene_index: int
 ) -> None:
+    """
+    Verify batch CLI list-mode produces an .ome.zarr with pixel-identical data.
+    """
     # Arrange
     runner = CliRunner()
-    tiff = LOCAL_RESOURCES_DIR / filename
+    src = LOCAL_RESOURCES_DIR / filename
 
-    out_dir = tmp_path / "converted_out"
+    out_dir = tmp_path / "list_out"
     out_dir.mkdir(exist_ok=True)
-    out_zarr = out_dir / f"{tiff.stem}.ome.zarr"
+
+    out_zarr = out_dir / f"{src.stem}.ome.zarr"
     if out_zarr.exists():
         shutil.rmtree(out_zarr)
 
     # Act
     result = runner.invoke(
-        main,
+        batch_main,
         [
-            "-m",
+            "--mode",
             "list",
-            "-P",
-            str(tiff),
-            "-o",
-            f"destination={out_dir}",
-            "-o",
-            "tbatch=1",
-            "-o",
-            f"scenes={scene_index}",
+            "--paths",
+            str(src),
+            "--destination",
+            str(out_dir),
+            "--tbatch",
+            "1",
+            "--scenes",
+            str(scene_index),
         ],
     )
-    assert result.exit_code == 0, result.output
 
     # Assert
-    assert out_zarr.is_dir(), f"Missing output for {filename}"
-    bio_in = BioImage(str(tiff))
+    assert result.exit_code == 0, result.output
+    assert out_zarr.is_dir(), f"Missing list output for {src.name}"
+
+    bio_in = BioImage(str(src))
     bio_in.set_scene(scene_index)
     bio_out = BioImage(str(out_zarr))
     bio_out.set_scene(0)
@@ -65,13 +118,19 @@ def test_batch_cli_list_mode(
 
 
 def test_batch_cli_csv_mode(tmp_path: pathlib.Path) -> None:
+    """
+    Verify batch CLI CSV-mode reads jobs from a CSV and produces
+    pixel-identical outputs.
+    """
     # Arrange
     runner = CliRunner()
 
     out_dir = tmp_path / "csv_out"
     out_dir.mkdir(exist_ok=True)
+
     csv_path = tmp_path / "jobs.csv"
     fieldnames = ["source", "destination", "scenes", "tbatch"]
+
     with open(csv_path, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
@@ -84,20 +143,24 @@ def test_batch_cli_csv_mode(tmp_path: pathlib.Path) -> None:
                     "tbatch": "1",
                 }
             )
+
+    # Clean any existing outputs
     for fn in ["s_1_t_1_c_1_z_1.ome.tiff", "s_3_t_1_c_3_z_5.ome.tiff"]:
         out_path = out_dir / f"{pathlib.Path(fn).stem}.ome.zarr"
         if out_path.exists():
             shutil.rmtree(out_path)
 
     # Act
-    result = runner.invoke(main, ["-m", "csv", "--csv-file", str(csv_path)])
-    assert result.exit_code == 0, result.output
+    result = runner.invoke(
+        batch_main,
+        ["--mode", "csv", "--csv-file", str(csv_path), "--destination", str(out_dir)],
+    )
 
     # Assert
-    tiff1 = LOCAL_RESOURCES_DIR / "s_1_t_1_c_1_z_1.ome.tiff"
-    tiff2 = LOCAL_RESOURCES_DIR / "s_3_t_1_c_3_z_5.ome.tiff"
-    jobs_counter = 0
-    for src in (tiff1, tiff2):
+    assert result.exit_code == 0, result.output
+
+    for src_name in ["s_1_t_1_c_1_z_1.ome.tiff", "s_3_t_1_c_3_z_5.ome.tiff"]:
+        src = LOCAL_RESOURCES_DIR / src_name
         out_z = out_dir / f"{src.stem}.ome.zarr"
         assert out_z.is_dir(), f"Missing CSV output for {src.name}"
 
@@ -110,5 +173,72 @@ def test_batch_cli_csv_mode(tmp_path: pathlib.Path) -> None:
         assert bio_in.dtype == bio_out.dtype
         assert bio_in.channel_names == bio_out.channel_names
         assert_array_equal(bio_out.get_image_data(), bio_in.get_image_data())
-        jobs_counter += 1
-    assert jobs_counter == 2
+
+
+@pytest.mark.parametrize(
+    "depth, expect_subdir_output",
+    [
+        (0, False),
+        (1, True),
+    ],
+    ids=["depth0-excludes-subdir", "depth1-includes-subdir"],
+)
+def test_batch_cli_dir_mode(
+    tmp_path: pathlib.Path,
+    depth: int,
+    expect_subdir_output: bool,
+) -> None:
+    """
+    Verify batch CLI dir-mode and respects --depth when scanning directories.
+    """
+    # Arrange
+    runner = CliRunner()
+
+    root = tmp_path / "root"
+    sub = root / "sub"
+    root.mkdir()
+    sub.mkdir()
+
+    a = LOCAL_RESOURCES_DIR / "s_1_t_1_c_1_z_1.ome.tiff"
+    b = LOCAL_RESOURCES_DIR / "s_3_t_1_c_3_z_5.ome.tiff"
+
+    top_file = root / a.name
+    sub_file = sub / b.name
+    shutil.copyfile(a, top_file)
+    shutil.copyfile(b, sub_file)
+
+    out_dir = tmp_path / f"dir_out_depth{depth}"
+    out_dir.mkdir()
+
+    # Act
+    result = runner.invoke(
+        batch_main,
+        [
+            "--mode",
+            "dir",
+            "--directory",
+            str(root),
+            "--depth",
+            str(depth),
+            "--pattern",
+            "*.ome.tiff",
+            "--destination",
+            str(out_dir),
+            "--tbatch",
+            "1",
+            "--scenes",
+            "0",
+        ],
+    )
+
+    # Assert
+    assert result.exit_code == 0, result.output
+
+    out_top = out_dir / f"{top_file.stem}.ome.zarr"
+    out_sub = out_dir / f"{sub_file.stem}.ome.zarr"
+
+    assert out_top.is_dir()
+    if expect_subdir_output:
+        assert out_sub.is_dir()
+    else:
+        assert not out_sub.exists()

--- a/scripts/benchmark/benchmark.py
+++ b/scripts/benchmark/benchmark.py
@@ -99,7 +99,7 @@ def _writer_kwargs_from_run(run: Dict[str, Any]) -> Dict[str, Any]:
         kw["dtype"] = str(kw["dtype"])
 
     # numeric-ish args
-    for key in ("memory_target", "tbatch", "start_T_src", "start_T_dest", "zarr_format"):
+    for key in ("memory_target", "tbatch", "start_t_src", "start_t_dest", "zarr_format"):
         if key in kw and kw[key] is not None:
             kw[key] = int(kw[key])
 


### PR DESCRIPTION
## Description 
The purpose of this PR was originally to resolve #30 #31 #32, We noticed that the docs didnt include --opts before params.(#30 ) This led to submission of #31 and #32 which showed that the help function was misleading even though the bugs were not directly present.

This had me thinking that there must be a better way to allow for common params between clis and still type check. This resulted in adding `ome_zarr_options` which provides a common param build for CLIs, It also helps to improve the help functions. 

### Changes

Most of the changes are migrating code from `cli_convert` to `ome_zarr_options` and improving docstrings / descriptions.
- Universalize CLI params in `ome_zarr_options`
- Refactor batch tests (+ error handling test)
- Refactor batch and single file CLIs to work with `ome_zarr_options`
- Updated Docs to reflect new usage 