### PR TITLE
bugfix: loop over tbatch batches instead of passing tbatch as total_T

### DIFF
--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -428,12 +428,17 @@ class OmeZarrConverter:
                 base_t_src = self._start_t_src or 0
                 base_t_dest = self._start_t_dest or 0
                 batch_size = self._tbatch or t_total
+                # find which axis index is T once (e.g. axis 0 in "TCYX")
+                t_axis = list(native_order).index("T")
                 for i in range(0, t_total, batch_size):
                     batch = min(batch_size, t_total - i)
+                    # pre-slice to this batch window so the writer only holds
+                    # the dask graph for these frames, not the full array
+                    slices = [slice(None)] * data_all.ndim
+                    slices[t_axis] = slice(base_t_src + i, base_t_src + i + batch)
                     writer.write_timepoints(
-                        data=data_all,
-                        start_T_src=base_t_src + i,
-                        start_T_dest=base_t_dest + i,
+                        data=data_all[tuple(slices)],
+                        start_T_dest=base_t_dest + i,  # advance destination each batch
                         total_T=batch,
                     )
             else:

--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -425,14 +425,16 @@ class OmeZarrConverter:
             t_total = int(getattr(r.dims, "T", 1)) if has_t else 1
 
             if has_t and t_total > 1:
-                kwargs: Dict[str, Any] = {"data": data_all}
-                if self._start_t_src is not None:
-                    kwargs["start_T_src"] = self._start_t_src
-                if self._start_t_dest is not None:
-                    kwargs["start_T_dest"] = self._start_t_dest
-                kwargs["total_T"] = (
-                    self._tbatch if self._tbatch is not None else t_total
-                )
-                writer.write_timepoints(**kwargs)
+                base_t_src = self._start_t_src or 0
+                base_t_dest = self._start_t_dest or 0
+                batch_size = self._tbatch or t_total
+                for i in range(0, t_total, batch_size):
+                    batch = min(batch_size, t_total - i)
+                    writer.write_timepoints(
+                        data=data_all,
+                        start_T_src=base_t_src + i,
+                        start_T_dest=base_t_dest + i,
+                        total_T=batch,
+                    )
             else:
                 writer.write_full_volume(data_all)


### PR DESCRIPTION
## Summary

- `tbatch` was being passed directly as `total_T` in a single `write_timepoints` call, causing only the first N frames to be written and silently discarding the rest
- Replaced with a loop that iterates over all timepoints in `tbatch`-sized batches, restoring the intended semantics from the old `write_t_batches()` implementation

Closes #38

## Test plan

- [x] Manually verified with a synthetic 5-timepoint zarr source and `tbatch=2` — all 5 frames present in output with correct data
- [x] Existing test suite passes (`test_file_to_zarr_multi_scene` uses `tbatch=1` and asserts full shape + data equality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)