### PR TITLE
feat(converter): parallel shard-aligned region writes via write_region

### DIFF
--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -1,5 +1,8 @@
+import itertools
+import math
 import re
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -52,6 +55,7 @@ class OmeZarrConverter:
         tbatch: Optional[int] = None,
         dtype: Optional[Union[str, np.dtype]] = None,
         auto_dask_cluster: bool = False,
+        max_write_workers: Optional[int] = None,
     ) -> None:
         """
         Initialize an OME-Zarr converter with flexible scene selection,
@@ -143,6 +147,14 @@ class OmeZarrConverter:
             If True, automatically spin up a local Dask cluster with
             8 workers (using `Cluster(n_workers=8).start()`) before any
             conv
+        max_write_workers : Optional[int]
+            When set, write data via parallel shard-aligned
+            ``write_region(lock=False)`` calls using a thread pool of this
+            size rather than ``write_full_volume`` / ``write_timepoints``.
+            Each call writes exactly one shard at every pyramid level with
+            no read-modify-write, enabling safe concurrent writes.  Requires
+            ``zarr_format=3`` with proportional shards.  Ignored when
+            ``start_t_src`` or ``start_t_dest`` is non-zero.
         """
         self.source = source
         self.destination = destination or str(Path.cwd())
@@ -196,6 +208,7 @@ class OmeZarrConverter:
         self._start_t_src = start_t_src
         self._start_t_dest = start_t_dest
         self._tbatch = None if tbatch is None else tbatch
+        self._max_write_workers = max_write_workers
 
     # -------------------------------------------------------------------------
     # Internal helpers
@@ -317,6 +330,49 @@ class OmeZarrConverter:
             return [tuple(int(x) for x in level_shapes_spec)]
         # Already per-level
         return [tuple(int(x) for x in level) for level in level_shapes_spec]
+
+    def _write_by_region(
+        self,
+        writer: OMEZarrWriter,
+        data_all: "np.ndarray",
+        *,
+        max_workers: int,
+    ) -> None:
+        """
+        Write ``data_all`` into the zarr store using parallel shard-aligned
+        ``write_region(lock=False)`` calls.
+
+        Iterates over every level-0 shard coordinate, slices the source array,
+        and calls ``write_region`` which propagates the write — downsampled — to
+        every pyramid level.  Because shards are proportional, each call touches
+        exactly one independent shard object at every level: no shard is shared
+        between two concurrent calls, so no lock is needed and there is no
+        read-modify-write.
+
+        The first shard is written synchronously before the thread pool starts
+        to ensure ``OMEZarrWriter._initialize()`` (which creates arrays and
+        metadata) runs exactly once on the calling thread.
+        """
+        shard0 = writer.shards_per_level[0]
+        shape0 = writer.level_shapes[0]
+        n_shards = tuple(math.ceil(s / sh) for s, sh in zip(shape0, shard0))
+        all_coords = list(itertools.product(*[range(n) for n in n_shards]))
+
+        def write_one(coords: Tuple[int, ...]) -> None:
+            region = tuple(
+                slice(c * sh, min((c + 1) * sh, shape0[ax]))
+                for ax, (c, sh) in enumerate(zip(coords, shard0))
+            )
+            writer.write_region(data_all[region], region, lock=False)
+
+        # First write initializes the zarr store (not thread-safe); remaining
+        # writes are safe to parallelize since the store is already open.
+        first, *rest = all_coords
+        write_one(first)
+
+        if rest:
+            with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                list(pool.map(write_one, rest))
 
     # -------------------------------------------------------------------------
     # Public
@@ -479,7 +535,20 @@ class OmeZarrConverter:
             has_t = "t" in axis_names
             t_total = int(getattr(r.dims, "T", 1)) if has_t else 1
 
-            if has_t and t_total > 1:
+            _use_region_write = (
+                self._max_write_workers is not None
+                and self._writer_zarr_format == 3
+                and writer.shards_per_level is not None
+                and not self._start_t_src
+                and not self._start_t_dest
+            )
+
+            if _use_region_write:
+                assert self._max_write_workers is not None
+                self._write_by_region(
+                    writer, data_all, max_workers=self._max_write_workers
+                )
+            elif has_t and t_total > 1:
                 base_t_src = self._start_t_src or 0
                 base_t_dest = self._start_t_dest or 0
                 batch_size = self._tbatch or t_total
@@ -493,7 +562,7 @@ class OmeZarrConverter:
                     slices[t_axis] = slice(base_t_src + i, base_t_src + i + batch)
                     writer.write_timepoints(
                         data=data_all[tuple(slices)],
-                        start_T_dest=base_t_dest + i,  # advance destination each batch
+                        start_T_dest=base_t_dest + i,
                         total_T=batch,
                     )
             else:

--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -358,21 +358,40 @@ class OmeZarrConverter:
         n_shards = tuple(math.ceil(s / sh) for s, sh in zip(shape0, shard0))
         all_coords = list(itertools.product(*[range(n) for n in n_shards]))
 
-        def write_one(coords: Tuple[int, ...]) -> None:
+        def write_one(args: Tuple[Tuple[slice, ...], np.ndarray]) -> None:
+            region, np_shard = args
+            writer.write_region(np_shard, region, lock=False)
+
+        def make_region(
+            coords: Tuple[int, ...]
+        ) -> Tuple[Tuple[slice, ...], np.ndarray]:
             region = tuple(
                 slice(c * sh, min((c + 1) * sh, shape0[ax]))
                 for ax, (c, sh) in enumerate(zip(coords, shard0))
             )
-            writer.write_region(data_all[region], region, lock=False)
+            # Compute on the calling thread: CZI readers are not thread-safe,
+            # so all reads must be serialized here before writes are parallelized.
+            return region, data_all[region].compute()
 
         # First write initializes the zarr store (not thread-safe); remaining
         # writes are safe to parallelize since the store is already open.
         first, *rest = all_coords
-        write_one(first)
+        write_one(make_region(first))
 
         if rest:
+            from collections import deque
+
             with ThreadPoolExecutor(max_workers=max_workers) as pool:
-                list(pool.map(write_one, rest))
+                # Pipeline: read on main thread (serialized, CZI-safe), write
+                # in pool (parallel).  Cap in-flight futures to max_workers so
+                # at most max_workers shard numpy arrays live in memory at once.
+                pending: deque = deque()
+                for coords in rest:
+                    while len(pending) >= max_workers:
+                        pending.popleft().result()
+                    pending.append(pool.submit(write_one, make_region(coords)))
+                for f in pending:
+                    f.result()
 
     # -------------------------------------------------------------------------
     # Public

--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -544,6 +544,15 @@ class OmeZarrConverter:
             )
 
             if _use_region_write:
+                # Rechunk to shard boundaries so each write_region call computes
+                # only its own shard's data.  Without this, a dask graph that
+                # isn't naturally aligned to shard regions (e.g. a timelapse CZI
+                # with T-interleaved storage) will re-read far more data than
+                # needed for each shard, serializing what should be parallel I/O.
+                shard0 = writer.shards_per_level[0]
+                data_all = data_all.rechunk(shard0)
+
+            if _use_region_write:
                 assert self._max_write_workers is not None
                 self._write_by_region(
                     writer, data_all, max_workers=self._max_write_workers

--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -334,64 +334,47 @@ class OmeZarrConverter:
     def _write_by_region(
         self,
         writer: OMEZarrWriter,
-        data_all: "np.ndarray",
+        source: str,
+        native_order: str,
+        scene_index: int,
+        shard_shape: Tuple[int, ...],
         *,
         max_workers: int,
     ) -> None:
         """
-        Write ``data_all`` into the zarr store using parallel shard-aligned
+        Write the full image into the zarr store via concurrent shard-aligned
         ``write_region(lock=False)`` calls.
 
-        Iterates over every level-0 shard coordinate, slices the source array,
-        and calls ``write_region`` which propagates the write — downsampled — to
-        every pyramid level.  Because shards are proportional, each call touches
-        exactly one independent shard object at every level: no shard is shared
-        between two concurrent calls, so no lock is needed and there is no
-        read-modify-write.
-
-        The first shard is written synchronously before the thread pool starts
-        to ensure ``OMEZarrWriter._initialize()`` (which creates arrays and
-        metadata) runs exactly once on the calling thread.
+        The zarr store is initialized once on the calling thread before the
+        pool starts, so ``_initialize()`` is never called from multiple threads
+        simultaneously.  Each worker then opens its own independent BioImage
+        instance (its own file handle and parser state), which allows CZI reads
+        to proceed concurrently across workers rather than serializing on a
+        single shared reader.
         """
-        shard0 = writer.shards_per_level[0]
+        writer._initialize()
+
         shape0 = writer.level_shapes[0]
-        n_shards = tuple(math.ceil(s / sh) for s, sh in zip(shape0, shard0))
+        n_shards = tuple(math.ceil(s / sh) for s, sh in zip(shape0, shard_shape))
         all_coords = list(itertools.product(*[range(n) for n in n_shards]))
 
-        def write_one(args: Tuple[Tuple[slice, ...], np.ndarray]) -> None:
-            region, np_shard = args
-            writer.write_region(np_shard, region, lock=False)
-
-        def make_region(
-            coords: Tuple[int, ...]
-        ) -> Tuple[Tuple[slice, ...], np.ndarray]:
+        def read_and_write(coords: Tuple[int, ...]) -> None:
+            # Independent reader per thread: own file handle, own parser state,
+            # so concurrent reads from the same CZI file are safe.
+            bio = BioImage(source)
+            bio.set_scene(scene_index)
+            data = bio.reader.get_image_dask_data(native_order).rechunk(shard_shape)
             region = tuple(
                 slice(c * sh, min((c + 1) * sh, shape0[ax]))
-                for ax, (c, sh) in enumerate(zip(coords, shard0))
+                for ax, (c, sh) in enumerate(zip(coords, shard_shape))
             )
-            # Compute on the calling thread: CZI readers are not thread-safe,
-            # so all reads must be serialized here before writes are parallelized.
-            return region, data_all[region].compute()
+            np_shard = data[region].compute()
+            writer.write_region(np_shard, region, lock=False)
 
-        # First write initializes the zarr store (not thread-safe); remaining
-        # writes are safe to parallelize since the store is already open.
-        first, *rest = all_coords
-        write_one(make_region(first))
-
-        if rest:
-            from collections import deque
-
-            with ThreadPoolExecutor(max_workers=max_workers) as pool:
-                # Pipeline: read on main thread (serialized, CZI-safe), write
-                # in pool (parallel).  Cap in-flight futures to max_workers so
-                # at most max_workers shard numpy arrays live in memory at once.
-                pending: deque = deque()
-                for coords in rest:
-                    while len(pending) >= max_workers:
-                        pending.popleft().result()
-                    pending.append(pool.submit(write_one, make_region(coords)))
-                for f in pending:
-                    f.result()
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = [pool.submit(read_and_write, c) for c in all_coords]
+            for f in futures:
+                f.result()
 
     # -------------------------------------------------------------------------
     # Public
@@ -563,18 +546,15 @@ class OmeZarrConverter:
             )
 
             if _use_region_write:
-                # Rechunk to shard boundaries so each write_region call computes
-                # only its own shard's data.  Without this, a dask graph that
-                # isn't naturally aligned to shard regions (e.g. a timelapse CZI
-                # with T-interleaved storage) will re-read far more data than
-                # needed for each shard, serializing what should be parallel I/O.
-                shard0 = writer.shards_per_level[0]
-                data_all = data_all.rechunk(shard0)
-
-            if _use_region_write:
                 assert self._max_write_workers is not None
+                shard0 = writer.shards_per_level[0]
                 self._write_by_region(
-                    writer, data_all, max_workers=self._max_write_workers
+                    writer,
+                    self.source,
+                    native_order,
+                    scene_index,
+                    shard0,
+                    max_workers=self._max_write_workers,
                 )
             elif has_t and t_total > 1:
                 base_t_src = self._start_t_src or 0

--- a/bioio_conversion/sharding.py
+++ b/bioio_conversion/sharding.py
@@ -7,10 +7,6 @@ from bioio_ome_zarr.writers.utils import multiscale_chunk_size_from_memory_targe
 _ATLAS_SIZE = 2048
 
 
-def _round_to_multiple(value: int, multiple: int) -> int:
-    return ((value + multiple - 1) // multiple) * multiple
-
-
 def _choose_zarr_layout(
     shape: Tuple[int, ...],
     dtype: Union[str, "np.dtype[Any]"],
@@ -132,14 +128,14 @@ def _proportional_shard(
         In the same axis order and length as ``shape``.
     """
     return tuple(
-        _round_to_multiple(
+        ((v + chunk_shape[ax] - 1) // chunk_shape[ax]) * chunk_shape[ax]
+        for ax in range(len(shape))
+        for v in (
             max(
                 chunk_shape[ax],
                 round(reference_shard[ax] * shape[ax] / reference_shape[ax]),
             ),
-            chunk_shape[ax],
         )
-        for ax in range(len(shape))
     )
 
 
@@ -192,12 +188,21 @@ def _choose_pyramid_layout(
         # axis), eventually exceeding the proportional target and forcing
         # _proportional_shard to pick a larger shard — breaking the constant
         # n_shards invariant required for lock-free region writes.
+        #
+        # For axes whose size is unchanged from level 0 (e.g. Z when the pyramid
+        # only halves X/Y), lock the chunk to chunk0 for that axis.  If it were
+        # allowed to grow, _proportional_shard would round up to a different
+        # chunk multiple, producing a different shard shape and triggering a
+        # spurious proportionality warning from write_region(lock=False).
         prop_target = tuple(
             max(1, round(shard0[ax] * lvl_shape[ax] / shape0[ax]))
             for ax in range(len(lvl_shape))
         )
         lvl_chunk = tuple(
-            min(lvl_chunk_raw[ax], prop_target[ax]) for ax in range(len(lvl_shape))
+            chunk0[ax]
+            if lvl_shape[ax] == shape0[ax]
+            else min(lvl_chunk_raw[ax], prop_target[ax])
+            for ax in range(len(lvl_shape))
         )
         all_chunks.append(lvl_chunk)
         all_shards.append(_proportional_shard(lvl_shape, lvl_chunk, shape0, shard0))

--- a/bioio_conversion/tests/converters/test_large_czi_converter.py
+++ b/bioio_conversion/tests/converters/test_large_czi_converter.py
@@ -1,0 +1,179 @@
+"""
+Integration tests for OmeZarrConverter using real large CZI files.
+
+These tests require large CZI files that are not checked in. They are
+automatically skipped when the files are not present (e.g. in CI).
+
+Run locally with:
+    pyenv shell bioio-conversion
+    pytest bioio_conversion/tests/converters/test_large_czi_converter.py -v -s
+"""
+
+import math
+import pathlib
+from typing import List, Tuple
+
+import bioio_czi
+import numpy as np
+import pytest
+import zarr
+
+from bioio_conversion.converters.ome_zarr_converter import OmeZarrConverter
+from bioio_conversion.sharding import _build_pyramid_shapes, _choose_pyramid_layout
+
+# ---------------------------------------------------------------------------
+# File paths and skip guards
+# ---------------------------------------------------------------------------
+
+_CZI_30GB = pathlib.Path(
+    "/Users/brian.whitney/Downloads/"
+    "41a_d6f_7ce_57d_e1b_7c9_641_0c1_ec0_281_2d_20260529_350008580_"
+    "AICS-57_3D_EGFP-TL_FastTimelapse-01-Lattice Lightsheet-11.czi"
+)
+
+requires_30gb_czi = pytest.mark.skipif(
+    not _CZI_30GB.exists(), reason=f"Large CZI not found: {_CZI_30GB.name}"
+)
+
+# Use the first 9 T-frames: produces exactly 3 T-shards (shard_T=3).
+# T=[0,3) is written synchronously (store initialisation); T=[3,6) and
+# T=[6,9) are written concurrently when max_write_workers=2.
+_TEST_T = 9
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _open_czi(path: pathlib.Path) -> bioio_czi.Reader:
+    r = bioio_czi.Reader(str(path))
+    r.set_scene(0)
+    return r
+
+
+def _level_shapes_for_t(
+    full_shape: Tuple[int, ...], dims: str, t_count: int
+) -> List[Tuple[int, ...]]:
+    shape_t = (t_count, *full_shape[1:])
+    return _build_pyramid_shapes(shape_t, dims)
+
+
+def _make_converter(
+    source: pathlib.Path,
+    out_dir: pathlib.Path,
+    name: str,
+    level_shapes: List[Tuple[int, ...]],
+    chunks: List[Tuple[int, ...]],
+    shards: List[Tuple[int, ...]],
+    *,
+    max_write_workers: int,
+) -> OmeZarrConverter:
+    return OmeZarrConverter(
+        source=str(source),
+        destination=str(out_dir),
+        name=name,
+        zarr_format=3,
+        level_shapes=level_shapes,
+        chunk_shape=chunks,
+        shard_shape=shards,
+        max_write_workers=max_write_workers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@requires_30gb_czi
+def test_concurrent_matches_sequential(tmp_path: pathlib.Path) -> None:
+    """
+    OmeZarrConverter with max_write_workers=2 (2 concurrent shards) must
+    produce bit-identical output to max_write_workers=1 (sequential shards)
+    at every pyramid level.
+
+    Both paths use write_region(lock=False). The only difference is that
+    max_workers=2 runs the 2nd and 3rd T-shards in parallel threads while
+    max_workers=1 runs them one at a time.
+    """
+    r = _open_czi(_CZI_30GB)
+    dims = r.dims.order.upper()
+    level_shapes = _level_shapes_for_t(r.shape, dims, _TEST_T)
+    chunks, shards = _choose_pyramid_layout(level_shapes, r.dtype, dims)
+
+    shard_t = shards[0][dims.index("T")]
+    n_t_shards = math.ceil(_TEST_T / shard_t)
+    assert n_t_shards == 3, f"Expected 3 T-shards, got {n_t_shards}"
+
+    # Sequential reference (max_workers=1 → write_region, no concurrency)
+    _make_converter(
+        _CZI_30GB,
+        tmp_path,
+        "sequential",
+        level_shapes,
+        chunks,
+        shards,
+        max_write_workers=1,
+    ).convert()
+
+    # Concurrent (max_workers=2 → T-shards 1 and 2 run in parallel)
+    _make_converter(
+        _CZI_30GB,
+        tmp_path,
+        "concurrent",
+        level_shapes,
+        chunks,
+        shards,
+        max_write_workers=2,
+    ).convert()
+
+    seq_grp = zarr.open_group(str(tmp_path / "sequential.ome.zarr"), mode="r")
+    con_grp = zarr.open_group(str(tmp_path / "concurrent.ome.zarr"), mode="r")
+
+    for lvl in range(len(level_shapes)):
+        np.testing.assert_array_equal(
+            seq_grp[str(lvl)][...],
+            con_grp[str(lvl)][...],
+            err_msg=f"Level {lvl} mismatch: sequential vs concurrent",
+        )
+
+
+@requires_30gb_czi
+def test_level0_matches_source(tmp_path: pathlib.Path) -> None:
+    """
+    Level 0 of the concurrent-write zarr must match the raw CZI source at
+    spot-checked coordinates, with one plane selected from each T-shard so
+    that both the synchronous init shard and the concurrent shards are covered.
+    """
+    r = _open_czi(_CZI_30GB)
+    dims = r.dims.order.upper()
+    level_shapes = _level_shapes_for_t(r.shape, dims, _TEST_T)
+    chunks, shards = _choose_pyramid_layout(level_shapes, r.dtype, dims)
+
+    _make_converter(
+        _CZI_30GB,
+        tmp_path,
+        "czi_test",
+        level_shapes,
+        chunks,
+        shards,
+        max_write_workers=2,
+    ).convert()
+
+    zarr_level0 = zarr.open_group(str(tmp_path / "czi_test.ome.zarr"), mode="r")["0"]
+    src = r.get_image_dask_data(dims)
+
+    shard_t = shards[0][dims.index("T")]  # 3
+    # One T from each shard: shard 0 (sync init), shard 1 and 2 (concurrent)
+    t_indices = [shard_t // 2, shard_t + shard_t // 2, 2 * shard_t + shard_t // 2]
+
+    for t in t_indices:
+        # C=0, Z=0, full YX plane
+        src_plane = src[t, 0, 0].compute()
+        zarr_plane = np.array(zarr_level0[t, 0, 0])
+        np.testing.assert_array_equal(
+            src_plane,
+            zarr_plane,
+            err_msg=f"Level 0 mismatch vs source at T={t} (shard {t // shard_t})",
+        )

--- a/run_write_benchmark.sh
+++ b/run_write_benchmark.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Submit the region-write benchmark job.
+# Usage: bash run_write_benchmark.sh
+
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+pyenv activate region-write
+
+SCRIPT=/allen/aics/users/brian.whitney/shard_benchmark.py
+LOGS=/allen/aics/users/brian.whitney/shard_benchmark4/logs
+mkdir -p "$LOGS"
+
+sbatch \
+    --job-name="region_write_bench" \
+    --ntasks=1 \
+    --cpus-per-task=8 \
+    --mem=64G \
+    --time=12:00:00 \
+    --output="${LOGS}/%j_region_write_bench.out" \
+    --error="${LOGS}/%j_region_write_bench.err" \
+    --wrap="python3 $SCRIPT"
+
+echo "Submitted: region write benchmark"

--- a/scripts/benchmark/benchmark.py
+++ b/scripts/benchmark/benchmark.py
@@ -99,7 +99,7 @@ def _writer_kwargs_from_run(run: Dict[str, Any]) -> Dict[str, Any]:
         kw["dtype"] = str(kw["dtype"])
 
     # numeric-ish args
-    for key in ("memory_target", "tbatch", "start_t_src", "start_t_dest", "zarr_format"):
+    for key in ("memory_target", "tbatch", "start_t_src", "start_t_dest", "zarr_format", "max_write_workers"):
         if key in kw and kw[key] is not None:
             kw[key] = int(kw[key])
 

--- a/scripts/benchmark/data_source.json
+++ b/scripts/benchmark/data_source.json
@@ -1,12 +1,21 @@
 {
   "runs": [
     {
-      "name": "2GB-czi-s0",
-      "size_label": "2.00 GB",
-      "source": "PATH or URL",
+      "name": "timelapse-default-write",
+      "size_label": "full-volume write",
+      "source": "/allen/programs/allencell/data/proj0/3a9/3df/1b4/466/c87/f2a/24d/a10/36e/6ec/eb/3500008271_20260227_20X_Timelapse.czi",
       "scenes": 0,
       "zarr_format": 3,
       "dtype": "uint16"
+    },
+    {
+      "name": "timelapse-region-write",
+      "size_label": "parallel region write",
+      "source": "/allen/programs/allencell/data/proj0/3a9/3df/1b4/466/c87/f2a/24d/a10/36e/6ec/eb/3500008271_20260227_20X_Timelapse.czi",
+      "scenes": 0,
+      "zarr_format": 3,
+      "dtype": "uint16",
+      "max_write_workers": 8
     }
   ]
 }

--- a/shard_benchmark.py
+++ b/shard_benchmark.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+shard_benchmark.py
+
+Convert one image to OME-Zarr v3 using the default auto-layout with parallel
+shard-aligned region writes.  Edit the CONFIG block, then run:
+
+    python shard_benchmark.py
+"""
+from __future__ import annotations
+
+import math
+import time
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+from bioio import BioImage
+from bioio_conversion.converters.ome_zarr_converter import OmeZarrConverter
+from bioio_conversion.sharding import _build_pyramid_shapes, _choose_pyramid_layout
+
+# ---------------------------------------------------------------------------
+# CONFIG
+# ---------------------------------------------------------------------------
+
+SOURCE = "/allen/programs/allencell/data/proj0/3a9/3df/1b4/466/c87/f2a/24d/a10/36e/6ec/eb/3500008271_20260227_20X_Timelapse.czi"
+DESTINATION = "/allen/aics/users/brian.whitney/shard_benchmark3"
+
+MAX_WRITE_WORKERS = 8
+
+# ---------------------------------------------------------------------------
+
+
+def _print_layout(
+    level_shapes: List[Tuple[int, ...]],
+    all_chunks: List[Tuple[int, ...]],
+    all_shards: List[Tuple[int, ...]],
+    dtype: np.dtype,
+) -> None:
+    for i, (shape, chunk, shard) in enumerate(zip(level_shapes, all_chunks, all_shards)):
+        shard_mb = math.prod(shard) * dtype.itemsize / 1024**2
+        print(
+            f"  level {i}: shape={shape}  chunk={chunk}  "
+            f"shard={shard}  ({shard_mb:.1f} MiB uncompressed)"
+        )
+
+
+def main() -> None:
+    bio = BioImage(SOURCE)
+    r = bio.reader
+    dims = r.dims.order.upper()
+    shape = tuple(int(getattr(r.dims, ax)) for ax in dims)
+    dtype = np.dtype(r.dtype)
+
+    level_shapes = _build_pyramid_shapes(shape, dims)
+    all_chunks, all_shards = _choose_pyramid_layout(level_shapes, dtype, dims)
+
+    stem = Path(SOURCE).stem.split(".")[0]
+    name = f"{stem}_region_write"
+
+    print(f"source:         {SOURCE}")
+    print(f"dims:           {dims}")
+    print(f"shape:          {shape}")
+    print(f"dtype:          {dtype}")
+    print(f"pyramid levels: {len(level_shapes)}")
+    _print_layout(level_shapes, all_chunks, all_shards, dtype)
+    print(f"max workers:    {MAX_WRITE_WORKERS}")
+    print(f"output:         {DESTINATION}/{name}.ome.zarr")
+    print()
+
+    t0 = time.perf_counter()
+    OmeZarrConverter(
+        source=SOURCE,
+        destination=DESTINATION,
+        name=name,
+        scenes=0,
+        zarr_format=3,
+        max_write_workers=MAX_WRITE_WORKERS,
+    ).convert()
+    elapsed = time.perf_counter() - t0
+
+    print(f"Done.  elapsed: {elapsed:.1f}s  ({elapsed / 60:.1f} min)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_large_czi.py
+++ b/test_large_czi.py
@@ -1,0 +1,192 @@
+"""
+Test write_region with large CZI files.
+
+Usage:
+    pyenv shell bioio-conversion
+    python test_large_czi.py [--file FILE] [--workers N] [--out DIR]
+
+Defaults:
+    --file   30GB lattice lightsheet CZI
+    --workers 1
+    --out    /tmp/test_ome_zarr
+"""
+
+import argparse
+import os
+import resource
+import shutil
+import time
+from pathlib import Path
+
+import numpy as np
+
+CZI_30GB = (
+    "/Users/brian.whitney/Downloads/"
+    "41a_d6f_7ce_57d_e1b_7c9_641_0c1_ec0_281_2d_20260529_350008580_"
+    "AICS-57_3D_EGFP-TL_FastTimelapse-01-Lattice Lightsheet-11.czi"
+)
+CZI_12GB = (
+    "/Users/brian.whitney/Downloads/"
+    "3a4_b28_74b_5e2_ddb_71a_24b_c2c_075_f35_f4_3500008770_"
+    "20260526_20X_Timelapse-01(35).czi"
+)
+
+
+def peak_rss_gb() -> float:
+    """Peak resident set size in GB (macOS/Linux)."""
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    # macOS reports in bytes; Linux reports in kilobytes
+    factor = 1 if os.uname().sysname == "Darwin" else 1024
+    return usage.ru_maxrss / factor / 1e9
+
+
+def inspect_czi(path: str) -> None:
+    import bioio_czi
+
+    print(f"\n--- Inspecting {Path(path).name} ---")
+    r = bioio_czi.Reader(path)
+    print(f"  scenes : {r.scenes}")
+    r.set_scene(0)
+    arr = r.get_image_dask_data(r.dims.order.upper())
+    dtype = r.dtype
+    uncompressed_gb = np.prod(arr.shape) * np.dtype(dtype).itemsize / 1e9
+    print(f"  dims   : {r.dims.order}  shape={arr.shape}  dtype={dtype}")
+    print(f"  native chunks : {arr.chunksize}")
+    print(f"  uncompressed  : {uncompressed_gb:.1f} GB")
+
+
+def preview_layout(path: str) -> None:
+    """Print the auto-computed pyramid / shard layout without writing anything."""
+    import bioio_czi
+    from bioio_conversion.sharding import (
+        _build_pyramid_shapes,
+        _choose_pyramid_layout,
+    )
+
+    r = bioio_czi.Reader(path)
+    r.set_scene(0)
+    arr = r.get_image_dask_data(r.dims.order.upper())
+    dims = r.dims.order.upper()
+    shape = arr.shape
+    dtype = r.dtype
+
+    level_shapes = _build_pyramid_shapes(shape, dims)
+    chunks, shards = _choose_pyramid_layout(level_shapes, dtype, dims)
+
+    print(f"\n--- Pyramid layout for {Path(path).name} ---")
+    for i, (s, c, sh) in enumerate(zip(level_shapes, chunks, shards)):
+        shard_gb = np.prod(sh) * np.dtype(dtype).itemsize / 1e9
+        n_shards = int(np.prod([int(np.ceil(s[ax] / sh[ax])) for ax in range(len(s))]))
+        print(
+            f"  level {i}: shape={s}  chunk={c}  shard={sh}"
+            f"  ({shard_gb:.2f} GB/shard × {n_shards} shards)"
+        )
+    peak_shard_gb = np.prod(shards[0]) * np.dtype(dtype).itemsize / 1e9
+    print(
+        f"\n  Expected peak RAM per worker: ~{peak_shard_gb * 1.25:.1f} GB"
+        f"  (shard + downsampled)"
+    )
+
+
+def run_conversion(
+    path: str,
+    out_dir: str,
+    *,
+    max_workers: int = 1,
+    cleanup: bool = True,
+) -> None:
+    from bioio_conversion.converters.ome_zarr_converter import OmeZarrConverter
+
+    out_path = Path(out_dir) / (Path(path).stem + ".ome.zarr")
+    if out_path.exists():
+        shutil.rmtree(out_path)
+
+    print(f"\n--- Converting {Path(path).name} ---")
+    print(f"  output      : {out_path}")
+    print(f"  max_workers : {max_workers}")
+    print(f"  RSS before  : {peak_rss_gb():.2f} GB")
+
+    conv = OmeZarrConverter(
+        source=str(path),
+        destination=out_dir,
+        zarr_format=3,
+        max_write_workers=max_workers,
+    )
+
+    t0 = time.perf_counter()
+    conv.convert()
+    elapsed = time.perf_counter() - t0
+
+    print(f"  RSS after   : {peak_rss_gb():.2f} GB")
+    print(f"  elapsed     : {elapsed:.1f} s")
+
+    if out_path.exists():
+        size_gb = sum(f.stat().st_size for f in out_path.rglob("*") if f.is_file()) / 1e9
+        print(f"  output size : {size_gb:.2f} GB (compressed)")
+
+    if cleanup and out_path.exists():
+        shutil.rmtree(out_path)
+        print("  cleaned up output")
+
+
+def verify_spot_check(
+    source_path: str,
+    zarr_path: str,
+    *,
+    t_idx: int = 0,
+    c_idx: int = 0,
+    z_idx: int = 0,
+) -> None:
+    """Read one YX plane from both source and zarr and compare."""
+    import bioio_czi
+    import zarr
+
+    print(f"\n--- Spot check (T={t_idx}, C={c_idx}, Z={z_idx}) ---")
+
+    r = bioio_czi.Reader(source_path)
+    r.set_scene(0)
+    dims = r.dims.order.upper()
+    src_arr = r.get_image_dask_data(dims)
+    idx = {d: [t_idx, c_idx, z_idx, slice(None), slice(None)][i] for i, d in enumerate(dims)}
+    src_plane = src_arr[tuple(idx[d] for d in dims)].compute()
+
+    root = zarr.open_group(zarr_path, mode="r")
+    zarray = root["0"]
+    dst_plane = zarray[t_idx, c_idx, z_idx]
+
+    match = np.array_equal(src_plane, dst_plane)
+    print(f"  source shape : {src_plane.shape}  dtype={src_plane.dtype}")
+    print(f"  zarr shape   : {dst_plane.shape}  dtype={dst_plane.dtype}")
+    print(f"  exact match  : {match}")
+    if not match:
+        diff = np.abs(src_plane.astype(int) - dst_plane.astype(int))
+        print(f"  max diff     : {diff.max()}  mean diff={diff.mean():.4f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--file", default=CZI_30GB)
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument("--out", default="/tmp/test_ome_zarr")
+    parser.add_argument("--inspect-only", action="store_true")
+    parser.add_argument("--no-cleanup", action="store_true")
+    args = parser.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+
+    inspect_czi(args.file)
+    preview_layout(args.file)
+
+    if args.inspect_only:
+        return
+
+    run_conversion(
+        args.file,
+        args.out,
+        max_workers=args.workers,
+        cleanup=args.no_cleanup is False,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `max_write_workers: Optional[int]` to `OmeZarrConverter`. When set with `zarr_format=3` and proportional shards, the converter uses `_write_by_region` instead of `write_full_volume`/`write_timepoints`.
- `_write_by_region` iterates over every level-0 shard coordinate and calls `write_region(lock=False)` for each. Because `_choose_pyramid_layout` (from the parent branch) guarantees the n_shards invariant across all pyramid levels, each call touches exactly one independent shard object at every level — no shard is shared between concurrent workers, no lock needed, no read-modify-write.
- The first shard is written synchronously before the thread pool starts so `OMEZarrWriter._initialize()` (zarr array creation + NGFF metadata) runs exactly once on the calling thread.

Falls back to `write_full_volume`/`write_timepoints` when `zarr_format != 3`, shards are absent, `start_t_src`/`start_t_dest` is non-zero, or `max_write_workers` is `None`.

## Test plan

- [ ] Existing 38 converter + sharding tests pass (no regression)
- [ ] Manually test with a large TCZYX (zarr_format=3) image and `max_write_workers=16`
- [ ] Verify no `UserWarning` from `write_region(lock=False)` for the 7-level TCZYX regression case (proportional shards throughout)
- [ ] Verify output is pixel-identical to `write_full_volume` path for a known small image

🤖 Generated with [Claude Code](https://claude.com/claude-code)