### PR TITLE
Default zarr_format to 3 so plain conversions build full pyramids

### DIFF
--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -26,9 +26,6 @@ from ..sharding import (
 # Bounds are ((lo, hi), ...) per axis — a picklable description of a shard region.
 _Bounds = Tuple[Tuple[int, int], ...]
 
-# Format used when the caller doesn't specify one. The v3 auto-pyramid /
-# auto-shard paths are gated on v3, so defaulting here ensures a plain
-# ``bioio-convert`` (no ``--zarr-format``) still produces a full pyramid.
 DEFAULT_ZARR_FORMAT = 3
 
 

--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -162,8 +162,8 @@ class OmeZarrConverter:
             Compression codec. For v2 use ``numcodecs.Blosc``; for v3 use
             ``zarr.codecs.BloscCodec``.
         zarr_format : Optional[int]
-            Target Zarr array format (``2`` or ``3``). ``None`` lets the writer
-            choose its default.
+            Target Zarr array format (``2`` or ``3``). Defaults to ``3`` when
+            ``None``.
         image_name : Optional[str]
             Image name to record in multiscales metadata. Defaults to the output base.
         channels : Optional[List[Channel]]

--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -26,6 +26,11 @@ from ..sharding import (
 # Bounds are ((lo, hi), ...) per axis — a picklable description of a shard region.
 _Bounds = Tuple[Tuple[int, int], ...]
 
+# Format used when the caller doesn't specify one. The v3 auto-pyramid /
+# auto-shard paths are gated on v3, so defaulting here ensures a plain
+# ``bioio-convert`` (no ``--zarr-format``) still produces a full pyramid.
+DEFAULT_ZARR_FORMAT = 3
+
 
 def _available_cores() -> int:
     """Number of cores the current process may actually run on.
@@ -244,7 +249,9 @@ class OmeZarrConverter:
         self._writer_chunk_shape = chunk_shape
         self._writer_shard_shape = shard_shape
         self._writer_compressor = compressor
-        self._writer_zarr_format = zarr_format
+        self._writer_zarr_format = (
+            DEFAULT_ZARR_FORMAT if zarr_format is None else zarr_format
+        )
         self._writer_image_name = image_name
         self._writer_channels = channels
         self._writer_rdefs = rdefs


### PR DESCRIPTION
## Problem

nd2 (and other) files were producing single-level, pyramid-less OME-Zarr stores when converted without an explicit `--zarr-format` flag — the way `bioio-conversion-pipeline` invokes `bioio-convert`.

## Verification

- Ran a real conversion on a ZCYX nd2 (305×4×1192×1192, uint16) with **no** `--zarr-format`: now produces a full **5-level** v3 pyramid with real downsampled data at every level (previously: 1 level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)