### PR TITLE
Bugfix/allow remote dest

### DIFF
--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -546,9 +546,14 @@ class OmeZarrConverter:
                 else f"{self.output_basename}_{scene_name}"
             )
             base = re.sub(r"[<>:\"/\\|?*]", "_", base)
-            out_path = Path(self.destination) / f"{base}.ome.zarr"
-            if out_path.exists():
-                raise FileExistsError(f"{out_path} already exists.")
+            if "://" in self.destination:
+                # Destination is a URI (e.g., S3, GCS, etc.)
+                out_path = self.destination.rstrip("/") + f"/{base}.ome.zarr"
+            else:
+                # Destination is a local path
+                out_path = Path(self.destination) / f"{base}.ome.zarr"
+                if out_path.exists():
+                    raise FileExistsError(f"{out_path} already exists.")
 
             # (6) Build writer kwargs
             writer_kwargs: Dict[str, Any] = {

--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -5,6 +5,7 @@ from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import fsspec
 import numcodecs
 import numpy as np
 import psutil
@@ -548,15 +549,17 @@ class OmeZarrConverter:
             )
             base = re.sub(r"[<>:\"/\\|?*]", "_", base)
 
-            if "://" in self.destination:
+            if fsspec.utils.get_protocol(self.destination) == "file":
+                # Destination is a local path
+                out_path = str(Path(self.destination) / f"{base}.ome.zarr")
+            else:
                 # Destination is a URI (e.g., S3, GCS, etc.)
                 out_path = self.destination.rstrip("/") + f"/{base}.ome.zarr"
-            else:
-                # Destination is a local path
-                out_pathlib_path = Path(self.destination) / f"{base}.ome.zarr"
-                if out_pathlib_path.exists():
-                    raise FileExistsError(f"{out_path} already exists.")
-                out_path = str(out_pathlib_path)
+                
+            fs, _ = fsspec.core.url_to_fs(self.destination)
+            if fs.exists(out_path):
+                raise FileExistsError(f"{out_path} already exists.")
+
 
             # (6) Build writer kwargs
             writer_kwargs: Dict[str, Any] = {

--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -555,11 +555,10 @@ class OmeZarrConverter:
             else:
                 # Destination is a URI (e.g., S3, GCS, etc.)
                 out_path = self.destination.rstrip("/") + f"/{base}.ome.zarr"
-                
+
             fs, _ = fsspec.core.url_to_fs(self.destination)
             if fs.exists(out_path):
                 raise FileExistsError(f"{out_path} already exists.")
-
 
             # (6) Build writer kwargs
             writer_kwargs: Dict[str, Any] = {

--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -133,8 +133,9 @@ class OmeZarrConverter:
         source : str
             Path to the input image (any format supported by BioImage).
         destination : Optional[str]
-            Local directory or remote URI under which to write the ``.ome.zarr`` output(s).
-            If ``None``, the converter will use the current working directory
+            Local directory or remote URI under which to write the ``.ome.zarr``
+            output(s). If ``None``, the converter will use the current working
+            directory
         scenes : Optional[Union[int, List[int]]]
             Which scene(s) to export:
             - ``None`` → export all scenes
@@ -546,18 +547,20 @@ class OmeZarrConverter:
                 else f"{self.output_basename}_{scene_name}"
             )
             base = re.sub(r"[<>:\"/\\|?*]", "_", base)
+
             if "://" in self.destination:
                 # Destination is a URI (e.g., S3, GCS, etc.)
                 out_path = self.destination.rstrip("/") + f"/{base}.ome.zarr"
             else:
                 # Destination is a local path
-                out_path = Path(self.destination) / f"{base}.ome.zarr"
-                if out_path.exists():
+                out_pathlib_path = Path(self.destination) / f"{base}.ome.zarr"
+                if out_pathlib_path.exists():
                     raise FileExistsError(f"{out_path} already exists.")
+                out_path = str(out_pathlib_path)
 
             # (6) Build writer kwargs
             writer_kwargs: Dict[str, Any] = {
-                "store": str(out_path),
+                "store": out_path,
                 "level_shapes": writer_level_shapes_param,
                 "dtype": self.output_dtype,
                 **{
@@ -603,7 +606,7 @@ class OmeZarrConverter:
 
     def _write_auto_layout_shards(
         self,
-        out_path: Path,
+        out_path: str,
         native_order: str,
         scene_index: int,
         auto_shards: MultiResolutionShapeSpec,
@@ -637,7 +640,7 @@ class OmeZarrConverter:
                     pool.submit(
                         _write_shard_process,
                         self.source,
-                        str(out_path),
+                        out_path,
                         native_order,
                         scene_index,
                         out_dtype_str,

--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -133,7 +133,7 @@ class OmeZarrConverter:
         source : str
             Path to the input image (any format supported by BioImage).
         destination : Optional[str]
-            Directory in which to write the ``.ome.zarr`` output(s).
+            Local directory or remote URI under which to write the ``.ome.zarr`` output(s).
             If ``None``, the converter will use the current working directory
         scenes : Optional[Union[int, List[int]]]
             Which scene(s) to export:

--- a/bioio_conversion/tests/converters/test_ome_zarr_converter.py
+++ b/bioio_conversion/tests/converters/test_ome_zarr_converter.py
@@ -306,6 +306,33 @@ def test_conversion_pixel_correctness(
     assert_array_equal(bio_out.get_image_data(), bio_in.get_image_data())
 
 
+def test_convert_fails_if_destination_exists(tmp_path: pathlib.Path) -> None:
+    """
+    Conversion must refuse to write over an existing output store. The first
+    conversion succeeds and creates ``<name>.ome.zarr``; a second conversion to
+    the same destination and name must raise ``FileExistsError`` rather than
+    clobbering or appending to the existing store.
+    """
+    src_path = LOCAL_RESOURCES_DIR / "s_1_t_1_c_1_z_1.ome.tiff"
+    zarr_name = "already_exists"
+
+    def _convert() -> None:
+        OmeZarrConverter(
+            source=str(src_path),
+            destination=str(tmp_path),
+            name=zarr_name,
+            scenes=0,
+        ).convert()
+
+    # First conversion creates the store.
+    _convert()
+    assert (tmp_path / f"{zarr_name}.ome.zarr").exists()
+
+    # Second conversion to the same path must fail.
+    with pytest.raises(FileExistsError):
+        _convert()
+
+
 def test_multiprocess_matches_singleprocess(tmp_path: pathlib.Path) -> None:
     """
     Concurrent lock-free shard writes (n_workers=2) must produce a byte-identical


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

Follows https://github.com/bioio-devs/bioio-ome-zarr/pull/157 to allow the conversion package to write directly to S3 stores. See related issue: https://github.com/AllenCell/bioio-conversion-pipeline/issues/16

### Description of Changes

Replace path building logic that assumed local destinations with logic that allows for remote destinations as well.

### Manual Tests
- [x] create environment using this branch + the related [bioio-ome-zarr branch](https://github.com/bioio-devs/bioio-ome-zarr/pull/157)
- [x] run zarr conversion on slurm, using bff-pipeline output bucket as destination
- [x] validate that using extant S3 path as destination causes failure
