### PR TITLE
Admin: add ND2 roundtrip and provenance tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.nd2 filter=lfs diff=lfs merge=lfs -text

--- a/bioio_conversion/tests/converters/test_ome_zarr_converter.py
+++ b/bioio_conversion/tests/converters/test_ome_zarr_converter.py
@@ -28,6 +28,11 @@ _TEST_SHARD_LIMIT = 256 * 1024  # 256 KiB — used for integration tests
         # CZIs
         ("s_1_t_1_c_1_z_1.czi", 0, [0]),  # CYX
         ("s_3_t_1_c_3_z_5.czi", 0, [0]),  # CZYX
+        # ND2s
+        ("ND2_dims_c2y32x32.nd2", 0, [0]),  # CYX, single scene
+        ("ND2_dims_t3c2y32x32.nd2", 0, [0]),  # TCYX, single scene
+        ("ND2_dims_p2z5t3-2c4y32x32.nd2", 0, [0]),  # TZCYX, scene 0
+        ("ND2_dims_p2z5t3-2c4y32x32.nd2", 1, [1]),  # TZCYX, scene 1
     ],
     ids=[
         "tiff-1scene-idx0",
@@ -36,6 +41,10 @@ _TEST_SHARD_LIMIT = 256 * 1024  # 256 KiB — used for integration tests
         "tiff-3scene-all",
         "czi-cyx-idx0",
         "czi-czyx-idx0",
+        "nd2-cyx",
+        "nd2-tcyx",
+        "nd2-tzcyx-scene0",
+        "nd2-tzcyx-scene1",
     ],
 )
 def test_file_to_zarr_multi_scene(

--- a/bioio_conversion/tests/converters/test_provenance.py
+++ b/bioio_conversion/tests/converters/test_provenance.py
@@ -7,6 +7,8 @@ from typing import Optional
 
 import pytest
 from bioio import BioImage
+from bioio_nd2 import Reader as ND2Reader
+from bioio_nd2.plates import PLATE_96
 
 from bioio_conversion.converters.ome_zarr_converter import OmeZarrConverter
 from bioio_conversion.provenance import _json_safe
@@ -51,6 +53,7 @@ def _root_attrs(store_path: pathlib.Path) -> dict:
         ("s_1_t_1_c_1_z_1.czi", "bioio-czi", 0),
         ("s_3_t_1_c_3_z_5.czi", "bioio-czi", 0),
         ("s_3_t_1_c_3_z_5.czi", "bioio-czi", 2),
+        ("ND2_dims_t3c2y32x32.nd2", "bioio-nd2", 0),
     ],
 )
 def test_provenance_attributes(
@@ -140,3 +143,29 @@ def test_czi_subblock_metadata_embedded(tmp_path: pathlib.Path) -> None:
     subblocks = native["ImageDocument"]["Subblocks"]["Subblock"]
     assert subblocks, "no Subblocks (aicspylibczi?)"
     assert all(isinstance(sb, dict) for sb in subblocks), "subblocks should be dicts"
+
+
+def test_nd2_provenance_use_plate_96(tmp_path: pathlib.Path) -> None:
+    """
+    use_plate_96=True via provenance_reader_kwargs should populate row/column
+    in standard_metadata with plate-derived values matching the reader directly.
+    """
+    src_name = "ND2_dims_p2z5t3-2c4y32x32.nd2"
+    src = str(LOCAL_RESOURCES_DIR / src_name)
+    _convert(
+        tmp_path,
+        src_name,
+        "out",
+        scenes=0,
+        provenance_reader_kwargs={"use_plate_96": True},
+    )
+
+    store = tmp_path / "out.ome.zarr"
+    sm = _root_attrs(store)["bioio"]["standard_metadata"]
+
+    ref = ND2Reader(src, plate=PLATE_96)
+    ref.set_scene(0)
+    assert sm["row"] is not None
+    assert sm["column"] is not None
+    assert sm["row"] == ref.row
+    assert sm["column"] == ref.column

--- a/bioio_conversion/tests/resources/ND2_dims_c2y32x32.nd2
+++ b/bioio_conversion/tests/resources/ND2_dims_c2y32x32.nd2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7319df4f83c16f33f7b2b2f1af21c8af4f3395d8ad29a345967daa28c9592739
+size 331776

--- a/bioio_conversion/tests/resources/ND2_dims_p2z5t3-2c4y32x32.nd2
+++ b/bioio_conversion/tests/resources/ND2_dims_p2z5t3-2c4y32x32.nd2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ad9973fb05b00281867a9014752d779d55a5ff5c6097ba1ff9fb07b44e38ef7
+size 1142784

--- a/bioio_conversion/tests/resources/ND2_dims_t3c2y32x32.nd2
+++ b/bioio_conversion/tests/resources/ND2_dims_t3c2y32x32.nd2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a137dc95688f43c678b132e6e416ed18bcdd4334f9393d6208b799bd2ad959d1
+size 352256

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = [
   "coverage>=5.1",
   "bioio-ome-tiff>=1.4.0",
   "bioio-czi>=2.8.0",
+  "bioio-nd2>=1.7.0",
   "pytest>=5.4.3",
   "pytest-cov>=2.9.0",
   "pytest-raises>=0.11",


### PR DESCRIPTION
Closes #71

Adds in Nd2 test files / tests. Covers the edge case of providing plate geometry to get wells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)