### PR TITLE
Bugfix: write provenance sidecars into the remote store

### DIFF
--- a/bioio_conversion/converters/ome_zarr_converter.py
+++ b/bioio_conversion/converters/ome_zarr_converter.py
@@ -632,7 +632,7 @@ class OmeZarrConverter:
 
             # Attach the source metadata XML sidecars under bioio/ now that the
             # store exists (as json).
-            write_sidecars(Path(out_path), bioio_sidecars)
+            write_sidecars(out_path, bioio_sidecars)
 
             if can_auto_layout:
                 self._write_auto_layout_shards(

--- a/bioio_conversion/provenance.py
+++ b/bioio_conversion/provenance.py
@@ -7,6 +7,7 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Tuple
 
+import fsspec
 import xmltodict
 from bioio import BioImage
 
@@ -209,13 +210,16 @@ class ProvenanceBuilder:
         return {PROVENANCE_ATTR_KEY: block}, sidecars
 
 
-def write_sidecars(store_path: Path, sidecars: Dict[str, Any]) -> None:
-    """Write metadata sidecar dicts."""
+def write_sidecars(store_path: str, sidecars: Dict[str, Any]) -> None:
+    """Write metadata sidecar dicts into the store."""
+    fs, root = fsspec.core.url_to_fs(str(store_path))
     for rel_path, content in sidecars.items():
         try:
-            sidecar_path = store_path / rel_path
-            sidecar_path.parent.mkdir(parents=True, exist_ok=True)
-            sidecar_path.write_text(json.dumps(content), encoding="utf-8")
+            sidecar_path = f"{root.rstrip('/')}/{rel_path}"
+            parent = sidecar_path.rsplit("/", 1)[0]
+            fs.makedirs(parent, exist_ok=True)
+            with fs.open(sidecar_path, "w") as handle:
+                handle.write(json.dumps(content))
         except Exception as exc:
             warnings.warn(
                 f"Could not write metadata sidecar {rel_path!r}: {exc}",

--- a/bioio_conversion/tests/converters/test_provenance.py
+++ b/bioio_conversion/tests/converters/test_provenance.py
@@ -1,10 +1,10 @@
 import dataclasses
 import datetime
 import json
-import os
 import pathlib
-from typing import Optional
+from typing import Optional, Union
 
+import fsspec
 import pytest
 from bioio import BioImage
 from bioio_nd2 import Reader as ND2Reader
@@ -30,7 +30,7 @@ from ..conftest import LOCAL_RESOURCES_DIR
 
 
 def _convert(
-    tmp_path: pathlib.Path,
+    destination: Union[str, pathlib.Path],
     src_name: str,
     out_name: str,
     *,
@@ -38,10 +38,10 @@ def _convert(
     provenance: bool = True,
     provenance_reader_kwargs: Optional[dict] = None,
 ) -> None:
-    """Convert a resource fixture into ``tmp_path`` with the given options."""
+    """Convert a resource fixture into ``destination`` with the given options."""
     OmeZarrConverter(
         source=str(LOCAL_RESOURCES_DIR / src_name),
-        destination=str(tmp_path),
+        destination=str(destination),
         name=out_name,
         scenes=scenes,
         zarr_format=3,
@@ -51,13 +51,19 @@ def _convert(
     ).convert()
 
 
-def _root_attrs(store_path: pathlib.Path) -> dict:
+def _read_json(store_path: Union[str, pathlib.Path], rel_path: str) -> dict:
+    """Read a JSON member of a store through the store's own filesystem."""
+    fs, root = fsspec.core.url_to_fs(str(store_path))
+    with fs.open(f"{root.rstrip('/')}/{rel_path}") as fh:
+        return json.load(fh)
+
+
+def _root_attrs(store_path: Union[str, pathlib.Path]) -> dict:
     """Read the root group's attributes from a v3 store's zarr.json."""
-    with open(store_path / "zarr.json") as fh:
-        return json.load(fh)["attributes"]
+    return _read_json(store_path, "zarr.json")["attributes"]
 
 
-def _provenance(store_path: pathlib.Path) -> dict:
+def _provenance(store_path: Union[str, pathlib.Path]) -> dict:
     """The provenance block from a store's root attributes."""
     return _root_attrs(store_path)[PROVENANCE_ATTR_KEY]
 
@@ -89,8 +95,7 @@ def test_provenance_attributes(
 
     store = tmp_path / "out.ome.zarr"
     assert bioio[STANDARD_METADATA_KEY] == STANDARD_METADATA_PATH
-    with open(store / bioio[STANDARD_METADATA_KEY]) as fh:
-        sm = json.load(fh)
+    sm = _read_json(store, bioio[STANDARD_METADATA_KEY])
 
     src = str(LOCAL_RESOURCES_DIR / src_name)
     meta = BioImage(src)
@@ -102,6 +107,7 @@ def test_provenance_attributes(
     assert sm == expected
 
 
+@pytest.mark.parametrize("protocol", ["file", "memory"])
 @pytest.mark.parametrize(
     "src_name, expected_sidecars",
     [
@@ -116,19 +122,17 @@ def test_provenance_attributes(
     ],
 )
 def test_metadata_json_sidecars(
-    tmp_path: pathlib.Path, src_name: str, expected_sidecars: list
+    tmp_path: pathlib.Path, protocol: str, src_name: str, expected_sidecars: list
 ) -> None:
     """Native, OME, and standard metadata are written as JSON sidecars."""
-    _convert(tmp_path, src_name, "s")
-    store = tmp_path / "s.ome.zarr"
+    destination = str(tmp_path) if protocol == "file" else f"memory://{tmp_path.name}"
+    _convert(destination, src_name, "s")
+    store = f"{destination}/s.ome.zarr"
     bioio = _provenance(store)
 
-    with open(store / bioio[NATIVE_METADATA_KEY]) as fh:
-        native = json.load(fh)
-    with open(store / bioio[OME_METADATA_KEY]) as fh:
-        ome = json.load(fh)
-    with open(store / bioio[STANDARD_METADATA_KEY]) as fh:
-        standard = json.load(fh)
+    native = _read_json(store, bioio[NATIVE_METADATA_KEY])
+    ome = _read_json(store, bioio[OME_METADATA_KEY])
+    standard = _read_json(store, bioio[STANDARD_METADATA_KEY])
 
     assert isinstance(native, dict)
     assert isinstance(ome, dict)
@@ -136,9 +140,9 @@ def test_metadata_json_sidecars(
     assert (bioio[NATIVE_METADATA_KEY] == bioio[OME_METADATA_KEY]) == (
         len(expected_sidecars) == 2
     )
-    sidecar_files = [
-        f for f in os.listdir(store) if f.endswith(".json") and f != "zarr.json"
-    ]
+    fs, root = fsspec.core.url_to_fs(store)
+    names = [name.rsplit("/", 1)[-1] for name in fs.ls(root, detail=False)]
+    sidecar_files = [f for f in names if f.endswith(".json") and f != "zarr.json"]
     assert sorted(sidecar_files) == sorted(expected_sidecars)
 
 
@@ -157,8 +161,7 @@ def test_czi_subblock_metadata_embedded(tmp_path: pathlib.Path) -> None:
         },
     )
     store = tmp_path / "czi.ome.zarr"
-    with open(store / _provenance(store)[NATIVE_METADATA_KEY]) as fh:
-        native = json.load(fh)
+    native = _read_json(store, _provenance(store)[NATIVE_METADATA_KEY])
     subblocks = native["ImageDocument"]["Subblocks"]["Subblock"]
     assert subblocks, "no Subblocks (aicspylibczi?)"
     assert all(isinstance(sb, dict) for sb in subblocks), "subblocks should be dicts"
@@ -180,9 +183,7 @@ def test_nd2_provenance_use_plate_96(tmp_path: pathlib.Path) -> None:
     )
 
     store = tmp_path / "out.ome.zarr"
-    bioio = _provenance(store)
-    with open(store / bioio[STANDARD_METADATA_KEY]) as fh:
-        sm = json.load(fh)
+    sm = _read_json(store, _provenance(store)[STANDARD_METADATA_KEY])
 
     ref = ND2Reader(src, plate="96")
     ref.set_scene(0)

--- a/bioio_conversion/tests/converters/test_provenance.py
+++ b/bioio_conversion/tests/converters/test_provenance.py
@@ -125,7 +125,7 @@ def test_metadata_json_sidecars(
     tmp_path: pathlib.Path, protocol: str, src_name: str, expected_sidecars: list
 ) -> None:
     """Native, OME, and standard metadata are written as JSON sidecars."""
-    destination = str(tmp_path) if protocol == "file" else f"memory://{tmp_path.name}"
+    destination = str(tmp_path) if protocol == "file" else "memory://" + tmp_path.name
     _convert(destination, src_name, "s")
     store = f"{destination}/s.ome.zarr"
     bioio = _provenance(store)


### PR DESCRIPTION
Closes #73

## Problem

`write_sidecars()` took a `pathlib.Path` and wrote via `Path.write_text`, so for any non-local destination the provenance sidecars landed on local disk instead of in the store. The call site wrapped the (correct) store URI in `Path()`, and pathlib collapses the scheme separator:

```python
Path("s3://bucket/out/x.ome.zarr")  ->  "s3:/bucket/out/x.ome.zarr"   # is_absolute() == False
```

## Change

`write_sidecars()` now takes a URI string and goes through fsspec (`url_to_fs`, `makedirs`, `fs.open`), so the sidecars follow the store for every protocol. The `Path()` wrapper is gone from the call site.

## Tests

`test_metadata_json_sidecars` is parametrized over the destination protocol, covering a local path and `memory://`. `memory://` stands in for any remote protocol without pulling in moto or s3fs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)