### PR TITLE
Feature: expose provenance options on the conversion CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,26 @@ align by channel index.
   `--channel-window-start`, `--channel-window-end`: per-channel windowing
   values. Only used when any window value is provided.
 
+**Provenance options**
+
+* `--include-provenance`: record where each store came from. Writes a
+  top-level `bioio_conversion` attributes block (source file name, reader
+  plugin, package versions, conversion timestamp) plus the source's
+  `standard_metadata`, OME and native metadata as JSON sidecars inside the
+  store. Off by default.
+* `--provenance-reader-kwargs`: JSON object of extra kwargs for the reader
+  opened to collect that metadata. Use it when richer metadata needs
+  different reader settings than the pixel read. Requires
+  `--include-provenance`.
+
+  * Example: `--provenance-reader-kwargs '{"plate": "96"}'` to let the ND2
+    reader derive well row/column from a 96-well plate layout.
+  * Example: `--provenance-reader-kwargs '{"use_aicspylibczi": true,
+    "include_subblock_metadata": true}'` to embed per-subblock CZI metadata.
+
+  The value is JSON so kwarg types survive intact — `"96"` stays a string and
+  `true` becomes a bool, rather than both arriving as text.
+
 **Axis metadata options**
 
 * `--axes-names`: comma-separated axis names in native axis order.
@@ -392,6 +412,20 @@ bioio-convert image_tczyx.tif -d out_axes \
 ```bash
 bioio-convert image.tif -d out_dir \
   --physical-pixel-sizes 1.0,1.0,0.4,0.108,0.108
+```
+
+**Provenance**
+
+```bash
+bioio-convert sample.czi -d out_dir --include-provenance
+```
+
+**Provenance with extra reader kwargs**
+
+```bash
+bioio-convert plate.nd2 -d out_dir \
+  --include-provenance \
+  --provenance-reader-kwargs '{"plate": "96"}'
 ```
 
 ---

--- a/bioio_conversion/bin/cli_batch_convert.py
+++ b/bioio_conversion/bin/cli_batch_convert.py
@@ -98,6 +98,11 @@ def main(
       # List mode
       bioio-batch-convert --mode list --paths a.ome.tiff b.ome.tiff \\
           --destination out
+
+    \b
+      # Provenance for every job in the batch
+      bioio-batch-convert --mode dir --directory data --destination out \\
+          --include-provenance
     """
     try:
         init_opts_typed = build_ome_zarr_init_opts(**kwargs)

--- a/bioio_conversion/bin/cli_convert.py
+++ b/bioio_conversion/bin/cli_convert.py
@@ -34,8 +34,25 @@ def main(source: str, **kwargs: Any) -> None:
           --num-levels 3 \\
           --downsample-z \\
           --chunk-shape 1,1,16,256,256
+
+    \b
+      # Recording provenance, with extra kwargs for the metadata reader
+      bioio-convert plate.nd2 \\
+          --destination out_dir \\
+          --include-provenance \\
+          --provenance-reader-kwargs '{"plate": "96"}'
     """
     try:
+        if (
+            kwargs.get("provenance_reader_kwargs") is not None
+            and not kwargs["include_provenance"]
+        ):
+            raise click.UsageError(
+                "--provenance-reader-kwargs requires --include-provenance; "
+                "without it no provenance is collected and the kwargs would "
+                "be silently ignored."
+            )
+
         init_opts = build_ome_zarr_init_opts(**kwargs)
         OmeZarrConverter(source=source, **init_opts).convert()
 

--- a/bioio_conversion/bin/ome_zarr_options.py
+++ b/bioio_conversion/bin/ome_zarr_options.py
@@ -623,10 +623,8 @@ def ome_zarr_options(
                 type=JsonDictType(),
                 default=None,
                 help=(
-                    "JSON object of extra kwargs for the reader opened to "
-                    "collect provenance metadata, for use when richer metadata "
-                    "needs different reader settings than the pixel read. "
-                    'Example: \'{"plate": "96"}\'. Requires '
+                    "JSON object of extra kwargs for the provenance metadata "
+                    'reader. Example: \'{"plate": "96"}\'. Requires '
                     "--include-provenance."
                 ),
             ),

--- a/bioio_conversion/bin/ome_zarr_options.py
+++ b/bioio_conversion/bin/ome_zarr_options.py
@@ -268,7 +268,7 @@ class JsonDictType(click.ParamType):
             parsed = json.loads(str(value))
         except json.JSONDecodeError as exc:
             self.fail(f"{value!r} is not valid JSON ({exc}).", param, ctx)
-            raise AssertionError("unreachable")
+            raise
 
         if not isinstance(parsed, dict):
             message = (
@@ -276,7 +276,6 @@ class JsonDictType(click.ParamType):
                 '\'{"plate": "96"}\'.'
             )
             self.fail(message, param, ctx)
-            raise AssertionError("unreachable")
 
         return parsed
 

--- a/bioio_conversion/bin/ome_zarr_options.py
+++ b/bioio_conversion/bin/ome_zarr_options.py
@@ -268,7 +268,6 @@ class JsonDictType(click.ParamType):
             parsed = json.loads(str(value))
         except json.JSONDecodeError as exc:
             self.fail(f"{value!r} is not valid JSON ({exc}).", param, ctx)
-            raise
 
         if not isinstance(parsed, dict):
             message = (

--- a/bioio_conversion/bin/ome_zarr_options.py
+++ b/bioio_conversion/bin/ome_zarr_options.py
@@ -1,3 +1,4 @@
+import json
 from typing import (
     Any,
     Callable,
@@ -49,6 +50,10 @@ class OmeZarrInitOptions(TypedDict, total=False):
     channels: List[Channel]
     physical_pixel_size: List[float]
     zarr_format: int
+
+    # provenance
+    include_provenance: bool
+    provenance_reader_kwargs: Dict[str, Any]
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -243,6 +248,37 @@ class OptionalStrListType(click.ParamType):
         for p in parts:
             out.append(None if p.lower() in self.NONE_TOKENS else p)
         return out
+
+
+class JsonDictType(click.ParamType):
+    """
+    Parse a JSON object into a dict:
+      '{"plate": "96"}' -> {"plate": "96"}
+    """
+
+    name = "json_dict"
+
+    def convert(
+        self,
+        value: Any,
+        param: Parameter,
+        ctx: Context,
+    ) -> Dict[str, Any]:
+        try:
+            parsed = json.loads(str(value))
+        except json.JSONDecodeError as exc:
+            self.fail(f"{value!r} is not valid JSON ({exc}).", param, ctx)
+            raise AssertionError("unreachable")
+
+        if not isinstance(parsed, dict):
+            message = (
+                f"{value!r} must be a JSON object of reader kwargs, for example "
+                '\'{"plate": "96"}\'.'
+            )
+            self.fail(message, param, ctx)
+            raise AssertionError("unreachable")
+
+        return parsed
 
 
 def _get(
@@ -571,6 +607,31 @@ def ome_zarr_options(
                     "provided, overrides --num-levels and --downsample-z."
                 ),
             ),
+            # ── Provenance ────────────────────────────────────────────────
+            click.option(
+                "--include-provenance",
+                is_flag=True,
+                default=False,
+                help=(
+                    "Record source provenance in each store: a top-level "
+                    "'bioio_conversion' attributes block naming the source "
+                    "file, reader plugin, package versions and conversion "
+                    "time, plus the source's standard, OME and native "
+                    "metadata as JSON sidecars. Off by default."
+                ),
+            ),
+            click.option(
+                "--provenance-reader-kwargs",
+                type=JsonDictType(),
+                default=None,
+                help=(
+                    "JSON object of extra kwargs for the reader opened to "
+                    "collect provenance metadata, for use when richer metadata "
+                    "needs different reader settings than the pixel read. "
+                    'Example: \'{"plate": "96"}\'. Requires '
+                    "--include-provenance."
+                ),
+            ),
             # ── Job slicing / scene selection ─────────────────────────────
             click.option(
                 "--tbatch",
@@ -712,6 +773,12 @@ def build_ome_zarr_init_opts(**kwargs: Any) -> OmeZarrInitOptions:
             w_start=kwargs.get("channel_window_start"),
             w_end=kwargs.get("channel_window_end"),
         )
+
+    # Provenance
+    if kwargs.get("include_provenance"):
+        init_opts["include_provenance"] = True
+    if kwargs.get("provenance_reader_kwargs") is not None:
+        init_opts["provenance_reader_kwargs"] = kwargs["provenance_reader_kwargs"]
 
     # Axes
     if kwargs.get("axes_names") is not None:

--- a/bioio_conversion/tests/test_conversion_cli.py
+++ b/bioio_conversion/tests/test_conversion_cli.py
@@ -1,12 +1,19 @@
+import json
 import pathlib
 from typing import List, Tuple
 
 import pytest
 from bioio import BioImage
+from bioio_nd2 import Reader as ND2Reader
 from click.testing import CliRunner
 from numpy.testing import assert_array_equal
 
 from bioio_conversion.bin.cli_convert import main
+from bioio_conversion.provenance import (
+    PROVENANCE_ATTR_KEY,
+    SOURCE_FILE_KEY,
+    STANDARD_METADATA_KEY,
+)
 
 from .conftest import LOCAL_RESOURCES_DIR
 
@@ -123,3 +130,90 @@ def test_cli_zarr_resolution_levels(
         tuple(int(x) for x in bio.resolution_level_dims[lvl]) for lvl in expected_levels
     ]
     assert actual_shapes == level_shapes[: len(expected_levels)]
+
+
+def _provenance_block(store: pathlib.Path) -> dict:
+    """The provenance block from a converted store's root attributes."""
+    with open(store / "zarr.json") as fh:
+        return json.load(fh)["attributes"][PROVENANCE_ATTR_KEY]
+
+
+def test_cli_include_provenance(tmp_path: pathlib.Path) -> None:
+    """--include-provenance writes the provenance block and its sidecars."""
+    # Arrange
+    runner = CliRunner()
+    tiff = LOCAL_RESOURCES_DIR / "s_1_t_1_c_1_z_1.ome.tiff"
+
+    # Act
+    result = runner.invoke(
+        main,
+        [str(tiff), "-d", str(tmp_path), "-n", "prov", "--include-provenance"],
+    )
+
+    # Assert
+    assert result.exit_code == 0, result.output
+    store = tmp_path / "prov.ome.zarr"
+    bioio = _provenance_block(store)
+    assert bioio[SOURCE_FILE_KEY] == tiff.name
+    assert (store / bioio[STANDARD_METADATA_KEY]).exists()
+
+
+def test_cli_provenance_reader_kwargs(tmp_path: pathlib.Path) -> None:
+    """
+    --provenance-reader-kwargs reaches the metadata reader: plate=96 lets the
+    ND2 reader derive well row/column, which the default reader leaves unset.
+    """
+    # Arrange
+    runner = CliRunner()
+    nd2 = LOCAL_RESOURCES_DIR / "ND2_dims_p2z5t3-2c4y32x32.nd2"
+
+    # Act
+    result = runner.invoke(
+        main,
+        [
+            str(nd2),
+            "-d",
+            str(tmp_path),
+            "-n",
+            "plate",
+            "-s",
+            "0",
+            "--include-provenance",
+            "--provenance-reader-kwargs",
+            '{"plate": "96"}',
+        ],
+    )
+
+    # Assert
+    assert result.exit_code == 0, result.output
+    store = tmp_path / "plate.ome.zarr"
+    with open(store / _provenance_block(store)[STANDARD_METADATA_KEY]) as fh:
+        sm = json.load(fh)
+
+    ref = ND2Reader(str(nd2), plate="96")
+    ref.set_scene(0)
+    assert sm["row"] == ref.row is not None
+    assert sm["column"] == ref.column is not None
+
+
+def test_cli_provenance_reader_kwargs_requires_flag(tmp_path: pathlib.Path) -> None:
+    """The kwargs are ignored without the flag, so the CLI rejects that up front."""
+    # Arrange
+    runner = CliRunner()
+    tiff = LOCAL_RESOURCES_DIR / "s_1_t_1_c_1_z_1.ome.tiff"
+
+    # Act
+    result = runner.invoke(
+        main,
+        [
+            str(tiff),
+            "-d",
+            str(tmp_path),
+            "--provenance-reader-kwargs",
+            '{"plate": "96"}',
+        ],
+    )
+
+    # Assert
+    assert result.exit_code != 0
+    assert "requires --include-provenance" in result.output


### PR DESCRIPTION
Closes #76

## Summary

Adds `--include-provenance` and `--provenance-reader-kwargs` to the shared `ome_zarr_options` decorator, so both `bioio-convert` and `bioio-batch-convert` pick them up. Until now `include_provenance` and `provenance_reader_kwargs` were reachable only from the Python API or a batch CSV column.

```bash
bioio-convert sample.czi -d out_dir --include-provenance

bioio-convert plate.nd2 -d out_dir \
  --include-provenance \
  --provenance-reader-kwargs '{"plate": "96"}'
```

## Tests

Three cases, scoped to what this change introduces:

1. `--include-provenance` writes the provenance block and its sidecars.
2. `--provenance-reader-kwargs` reaches the metadata reader — `plate=96` yields well row/column matching a directly constructed `ND2Reader(plate="96")`. A default reader leaves those `None`, so this alone proves the kwargs were forwarded.
3. The usage guard fires when the kwargs are passed without the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)